### PR TITLE
Must use Lwt_unix.fork instead of Unix.fork

### DIFF
--- a/src/extensions/ocsipersist-dbm/ocsipersist.ml
+++ b/src/extensions/ocsipersist-dbm/ocsipersist.ml
@@ -93,10 +93,10 @@ let rec try_connect sname =
         Unix.close Unix.stdin;
         Unix.execv !ocsidbm param
       in
-      let pid = Unix.fork () in
+      let pid = Lwt_unix.fork () in
       if pid = 0
       then begin (* double fork *)
-        if Unix.fork () = 0
+        if Lwt_unix.fork () = 0
         then begin
           child ()
         end

--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -1413,7 +1413,7 @@ let start_server () = try
         set_passwd_if_needed sslinfo;
         if (get_daemon ())
         then
-          let pid = Unix.fork () in
+          let pid = Lwt_unix.fork () in
           if pid = 0
           then run user_info sslinfo threadinfo h
           else begin


### PR DESCRIPTION
If ocsigenserver is daemonized, and it does something with Lwt prior to forking
then it will deadlock.

To reproduce set an invalid hostname for example, and see that it fails to bind
to the port:
$ sudo hostname invalid
$ sudo `opam config var bin`/ocsigenserver.opt  --daemon
ocsigenserver.opt: main: Cannot determine default host name. Will use "invalid" to create absolute links or redirections dynamically if you do not set <host defaulthostname="..." ...> in config file.
$ sudo netstat -ntpa|grep ocsi

This is because printing the error message uses Lwt, and then you cannot use
Unix.fork without resetting Lwt after the fork!

Set good hostname again and it works:
$ sudo hostname <good-hostname>
$ sudo `opam config var bin`/ocsigenserver.opt  --daemon
$ sudo netstat -ntpa|grep ocsi
tcp        0      0 0.0.0.0:80              0.0.0.0:\*               LISTEN      15288/ocsigenserver
tcp6       0      0 :::80                   :::\*                    LISTEN      15288/ocsigenserver
