### PR TITLE
Ocsigen_http_com: avoid O(response) allocation by using Lwt_io, 2X speedup

### DIFF
--- a/opam
+++ b/opam
@@ -23,7 +23,7 @@ depends: [
   "base-threads"
   "react"
   "ssl"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.5.0"}
   "ocamlnet" {>= "4.0.2"}
   "pcre"
   "cryptokit"


### PR DESCRIPTION

Lwt_chan (deprecated) is now built atop Lwt_io and allocates a buffer on every
write. Refer to #49.

This makes ocsigenserver over 2X faster at serving large files, and also gives
a measurable improvement (~20%) for smaller ones (in the 10 KB range).