### PR TITLE
Use buffer pool to avoid large buffer allocation for connections and responses

### DIFF
--- a/src/Makefile.filelist
+++ b/src/Makefile.filelist
@@ -2,6 +2,7 @@ BIN := server/${PROJECTNAME}
 NATBIN := server/${PROJECTNAME}.opt
 
 INTF := baselib/ocsigen_cache.cmi	   \
+	baselib/ocsigen_buffer_pool.cmi	   \
 	baselib/ocsigen_lib_base.cmi	   \
 	baselib/ocsigen_lib.cmi	   \
 	baselib/ocsigen_config.cmi	   \

--- a/src/baselib/.depend
+++ b/src/baselib/.depend
@@ -1,5 +1,6 @@
 ocsigen_loader.cmi :
 ocsigen_cache.cmi :
+ocsigen_buffer_pool.cmi :
 ocsigen_stream.cmi :
 ocsigen_config.cmi : ocsigen_lib.cmi
 ocsigen_messages.cmi :
@@ -13,6 +14,8 @@ dynlink_wrapper.nonatdynlink.cmo :
 dynlink_wrapper.nonatdynlink.cmx :
 ocsigen_cache.cmo : ocsigen_cache.cmi
 ocsigen_cache.cmx : ocsigen_cache.cmi
+ocsigen_buffer_pool.cmo : ocsigen_buffer_pool.cmi
+ocsigen_buffer_pool.cmx : ocsigen_buffer_pool.cmi
 ocsigen_commandline.cmo : ocsigen_getcommandline.cmi ocsigen_config.cmi
 ocsigen_commandline.cmx : ocsigen_getcommandline.cmi ocsigen_config.cmx
 ocsigen_config.cmo : ocsigen_lib.cmi ocsigen_config.cmi

--- a/src/baselib/Makefile
+++ b/src/baselib/Makefile
@@ -25,6 +25,7 @@ all: byte opt
 FILES := ocsigen_lib_base.ml       \
 	 ocsigen_lib.ml            \
 	 ocsigen_cache.ml          \
+	 ocsigen_buffer_pool.ml    \
          ocsigen_config.ml         \
 	 ocsigen_commandline.ml    \
 	 ocsigen_messages.ml       \

--- a/src/baselib/ocsigen_buffer_pool.ml
+++ b/src/baselib/ocsigen_buffer_pool.ml
@@ -1,0 +1,122 @@
+(* Copyright (C) 2015 Mauricio Fernandez
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*)
+
+module POOL :
+sig
+  type 'a t
+
+  val make : (unit -> 'a) -> int -> 'a t
+  val take : 'a t -> 'a
+  val give_back : 'a t -> 'a -> unit
+end =
+struct
+  type 'a t =
+      {
+        create   : unit -> 'a;
+        q        : 'a Stack.t;
+        capacity : int;
+        mutable q_size : int;
+      }
+
+  let make create capacity =
+    { create; capacity;
+      q_size = 0;
+      q = Stack.create ();
+    }
+
+  let take t =
+    if Stack.is_empty t.q then
+       t.create ()
+    else
+      let x = Stack.pop t.q in
+        t.q_size <- t.q_size - 1;
+        x
+
+  let give_back t x =
+    if t.q_size < t.capacity then begin
+      Stack.push x t.q;
+      t.q_size <- t.q_size + 1;
+    end
+end
+
+let round_to_pow2 n =
+  let m = ref 1 in
+    while !m < n do
+      m := !m * 2;
+    done;
+    !m
+
+let is_pow2 n =
+  let m = n lor (n lsr 1) in
+  let m = m lor (m lsr 2) in
+  let m = m lor (m lsr 4) in
+  let m = m lor (m lsr 8) in
+  let m = m lor (m lsr 16) in
+    n land (m lsr 1) = 0
+
+let make_buffer_pool ?(min_size = 64) ?(max_size = 65536) create capacity =
+  let h = Hashtbl.create 13 in
+
+  let get_pool size =
+    try
+      Hashtbl.find h size
+    with Not_found ->
+      let p = POOL.make (fun () -> create size) (capacity size) in
+        Hashtbl.add h size p;
+        p in
+
+  let get ~exact size =
+    if (exact && not (is_pow2 size)) || size < min_size || size > max_size then
+      (create size, (fun () -> ()))
+    else
+      let p = get_pool (round_to_pow2 size) in
+      let x = POOL.take p in
+
+      let released = ref false in
+
+      let release () =
+        if not !released then begin
+          released := true;
+          POOL.give_back p x
+        end
+      in
+        (x, release)
+  in
+    (`Round_up (get ~exact:false), `Exact (get ~exact:true))
+
+let `Round_up get_bytes, `Exact get_bytes_exact =
+  make_buffer_pool Bytes.create (fun _ -> 256)
+
+let `Round_up get_lwt_bytes, `Exact get_lwt_bytes_exact =
+  make_buffer_pool Lwt_bytes.create (fun _ -> 256)
+
+let dummy_get_bytes n       = (Bytes.create n, (fun () -> ()))
+let dummy_get_lwt_bytes   n = (Lwt_bytes.create n, (fun () -> ()))
+
+let get_bytes, get_bytes_exact =
+  try
+    ignore (Unix.getenv "OCSIGEN_DISABLE_BUFFER_POOL");
+    (dummy_get_bytes, dummy_get_bytes)
+  with Not_found ->
+    (get_bytes, get_bytes_exact)
+
+let get_lwt_bytes, get_lwt_bytes_exact =
+  try
+    ignore (Unix.getenv "OCSIGEN_DISABLE_BUFFER_POOL");
+    (dummy_get_lwt_bytes, dummy_get_lwt_bytes)
+  with Not_found ->
+    (get_lwt_bytes, get_lwt_bytes_exact)

--- a/src/baselib/ocsigen_buffer_pool.mli
+++ b/src/baselib/ocsigen_buffer_pool.mli
@@ -1,0 +1,87 @@
+(* Copyright (C) 2015 Mauricio Fernandez
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*)
+
+(**
+   Buffer pools.
+
+   Not (preemptive) thread safe.
+
+   @author Mauricio Fernandez
+*)
+
+(** [make_buffer_pool ?min_size ?max_size make capacity]
+  * returns two functions [`Round_up f] and [`Exact g] that are invoked as
+  * in [f wanted_size] and return a buffer of the wanted size and a function
+  * to release the buffer and return it to the pool. These functions do not
+  * block and will return a buffer immediately.
+  *
+  * [f] will round up the size to a power of two. [g] will not, and will thus
+  * allocate fresh buffers if invoked with sizes that are not powers of two.
+  *
+  * [make_buffer_pool] is used as follows:
+  *
+  * {|
+  *   let `Round_up get_buf, `Exact get_buf_exact =
+  *     make_buffer_pool ?min_size ?max_size allocate_buffer
+  *     (fun n -> how_many_buffers_to_keep_at_most n)
+  *
+  *   ...
+  *   let b, release = get_buf 4096 in
+  *   ...
+  *
+  *   release ()
+  * ]}
+  *
+  * The release function can be invoked any number of times (the second and
+  * later calls are NOPs). If not invoked, the buffer will not be returned to
+  * the pool, but this is usually harmless (it only means there will be more
+  * allocation later in time).
+  *
+  * The returned buffers must not be used after they have been released, as
+  * they might have been reused at that point.
+  *
+  * @param min_size buffers of size under [min_size] are not pooled (and
+  * always freshly allocated with [make size] (default: 64)
+  *
+  * @param max_size buffers of size over [max_size] are not pooled (and
+  * always freshly allocated with [make size] (default: 65536)
+  *
+  * @param capacity is used to compute how many buffers to retain at most (as a
+  * function of the corresponding size). If [capacity n] returns [m], that
+  * means that the the pool will hold at most [m] buffers. Note that buffers
+  * are allocated lazily (only when the pool is empty), and the actual number
+  * of buffers (of a given size) allocated depends on how many are used
+  * simultaneously (before being released).
+  * *)
+
+val make_buffer_pool :
+  ?min_size:int ->
+  ?max_size:int ->
+  (int -> 'a) ->
+  (int -> int) ->
+  [`Round_up of int -> 'a * (unit -> unit) ] *
+  [`Exact of int -> 'a * (unit -> unit) ]
+
+(** {2 Buffer allocation against internal Ocsigen pools.}
+  *
+  * Pooling can be disabled altogether (for benchmark or other purposes) by
+  * setting the [OCSIGEN_DISABLE_BUFFER_POOL] environment variable.
+  * *)
+val get_bytes           : int -> Bytes.t * (unit -> unit)
+val get_bytes_exact     : int -> Bytes.t * (unit -> unit)
+val get_lwt_bytes       : int -> Lwt_bytes.t * (unit -> unit)
+val get_lwt_bytes_exact : int -> Lwt_bytes.t * (unit -> unit)

--- a/src/extensions/.depend
+++ b/src/extensions/.depend
@@ -35,12 +35,14 @@ cors.cmx : ../server/ocsigen_request_info.cmx ../baselib/ocsigen_lib.cmx \
     ../http/ocsigen_http_frame.cmx ../server/ocsigen_extensions.cmx \
     ../http/http_headers.cmx ../http/framepp.cmx
 deflatemod.cmo : ../baselib/ocsigen_stream.cmi \
-    ../server/ocsigen_request_info.cmi ../http/ocsigen_http_frame.cmi \
-    ../http/ocsigen_headers.cmi ../server/ocsigen_extensions.cmi \
+    ../server/ocsigen_request_info.cmi ../baselib/ocsigen_lib.cmi \
+    ../http/ocsigen_http_frame.cmi ../http/ocsigen_headers.cmi \
+    ../server/ocsigen_extensions.cmi ../baselib/ocsigen_buffer_pool.cmi \
     ../http/http_headers.cmi
 deflatemod.cmx : ../baselib/ocsigen_stream.cmx \
-    ../server/ocsigen_request_info.cmx ../http/ocsigen_http_frame.cmx \
-    ../http/ocsigen_headers.cmx ../server/ocsigen_extensions.cmx \
+    ../server/ocsigen_request_info.cmx ../baselib/ocsigen_lib.cmx \
+    ../http/ocsigen_http_frame.cmx ../http/ocsigen_headers.cmx \
+    ../server/ocsigen_extensions.cmx ../baselib/ocsigen_buffer_pool.cmx \
     ../http/http_headers.cmx
 extendconfiguration.cmo : ../server/ocsigen_parseconfig.cmi \
     ../server/ocsigen_extensions.cmi ../http/ocsigen_cookies.cmi \

--- a/src/http/.depend
+++ b/src/http/.depend
@@ -36,12 +36,12 @@ ocsigen_headers.cmx : ocsigen_senders.cmx ../baselib/ocsigen_lib.cmx \
     ocsigen_headers.cmi
 ocsigen_http_com.cmo : ../baselib/ocsigen_stream.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_http_frame.cmi ocsigen_cookies.cmi \
-    ../baselib/ocsigen_config.cmi http_lexer.cmo http_headers.cmi framepp.cmi \
-    ocsigen_http_com.cmi
+    ../baselib/ocsigen_config.cmi ../baselib/ocsigen_buffer_pool.cmi \
+    http_lexer.cmo http_headers.cmi framepp.cmi ocsigen_http_com.cmi
 ocsigen_http_com.cmx : ../baselib/ocsigen_stream.cmx \
     ../baselib/ocsigen_lib.cmx ocsigen_http_frame.cmx ocsigen_cookies.cmx \
-    ../baselib/ocsigen_config.cmx http_lexer.cmx http_headers.cmx framepp.cmx \
-    ocsigen_http_com.cmi
+    ../baselib/ocsigen_config.cmx ../baselib/ocsigen_buffer_pool.cmx \
+    http_lexer.cmx http_headers.cmx framepp.cmx ocsigen_http_com.cmi
 ocsigen_http_frame.cmo : ../baselib/ocsigen_stream.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_cookies.cmi http_headers.cmi \
     ocsigen_http_frame.cmi

--- a/src/http/.depend
+++ b/src/http/.depend
@@ -51,11 +51,13 @@ ocsigen_http_frame.cmx : ../baselib/ocsigen_stream.cmx \
 ocsigen_senders.cmo : ../baselib/ocsigen_stream.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_http_frame.cmi ocsigen_http_com.cmi \
     ocsigen_cookies.cmi ../baselib/ocsigen_config.cmi \
-    ocsigen_charset_mime.cmi http_headers.cmi ocsigen_senders.cmi
+    ocsigen_charset_mime.cmi ../baselib/ocsigen_buffer_pool.cmi \
+    http_headers.cmi ocsigen_senders.cmi
 ocsigen_senders.cmx : ../baselib/ocsigen_stream.cmx \
     ../baselib/ocsigen_lib.cmx ocsigen_http_frame.cmx ocsigen_http_com.cmx \
     ocsigen_cookies.cmx ../baselib/ocsigen_config.cmx \
-    ocsigen_charset_mime.cmx http_headers.cmx ocsigen_senders.cmi
+    ocsigen_charset_mime.cmx ../baselib/ocsigen_buffer_pool.cmx \
+    http_headers.cmx ocsigen_senders.cmi
 test_parser.cmo : ocsigen_http_frame.cmi http_lexer.cmo
 test_parser.cmx : ocsigen_http_frame.cmx http_lexer.cmx
 test_pp.cmo : ocsigen_http_frame.cmi framepp.cmi

--- a/src/http/ocsigen_http_com.mli
+++ b/src/http/ocsigen_http_com.mli
@@ -102,6 +102,7 @@ val send :
   unit Lwt.t
 
 val abort : connection -> unit
+val discard : connection -> unit
 
 
 (** Use this function to make an action just before sending the result 

--- a/src/http/ocsigen_senders.ml
+++ b/src/http/ocsigen_senders.ml
@@ -241,9 +241,31 @@ struct
       end else begin
         if read = buffer_size
         then Ocsigen_stream.cont buf read_aux
-        else Ocsigen_stream.cont (String.sub buf 0 read) read_aux
+        else begin
+          let rec return_fragment release_prev off size remaining () =
+            release_prev ();
+            if remaining = 0 then begin
+              release ();
+              Ocsigen_stream.empty None
+            end else if remaining <= 128 then begin
+              Ocsigen_stream.cont (Bytes.sub buf off remaining)
+                (return_fragment (fun () -> ()) (off + size) (size / 2) 0)
+            end else if remaining >= size then begin
+              (* size should be a power of two, but we take no chances here *)
+              let next_buf, release_next = Ocsigen_buffer_pool.get_bytes_exact size in
+                Bytes.blit buf off next_buf 0 size;
+                Ocsigen_stream.cont next_buf
+                  (return_fragment release_next
+                     (off + size) (size / 2) (remaining - size))
+            end else begin
+              return_fragment (fun () -> ()) off (size / 2) remaining ()
+            end
+          in
+            return_fragment (fun () -> ()) 0 (buffer_size / 2) read ()
+        end
       end
-    in read_aux
+    in
+      read_aux
 
   let get_etag_aux st =
     Some (Printf.sprintf "%Lx-%x-%f" st.Unix.LargeFile.st_size

--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -936,7 +936,9 @@ let handle_connection port in_ch sockaddr =
       )
 
   in (* body of handle_connection *)
-  handle_request ()
+    Lwt.finalize
+       handle_request
+       (fun () -> return (Ocsigen_http_com.discard receiver))
 
 let rec wait_connection use_ssl port socket =
   let handle_exn e =


### PR DESCRIPTION
A trivial buffer pool is used to get rid of these buffer allocations:
* per connection/receiver buffers (`Ocsigen_http_com`)
* internal buffer in `Ocsigen_senders.File_content`
* internal buffer in deflatemod

Moreover, some care is taken to avoid allocation for the last chunk of a file when the remaining data doesn't match the buffer size.

The changes are minimal, but reviews are appreciated. In particular:
* I haven't tested deflatemod yet
* I made a mistake in my first attempt at addressing the last-chunk issue (forgot that the buffer size could be rounded up to the next power of two), so any extra eyeballs to look for errors would help 
* I had to release the response stream resources (i.e. buffers) in `Ocsigen_server`; it's literally 3 lines, but it's quite big conceptually

Overall, these changes deliver up to ~25-30% more speed in some requests.

# Performance


## Effect of buffer pools

(buffer pool disabled with OCSIGEN_DISABLE_BUFFER_POOL -> enabled)
o=150 is the GC setting used in half of the runs

    404
            12000 -> 12800
     o=150  12900 -> 13500
            

    normal response (20 bytes)
            ~ 8100 -> 8900
      o=150 ~ 8400 -> 8900


    16kb file ->
              6721 -> 7800
       o=150  7100 -> 7900
       


## Effect of last-chunk optimization when serving files

    PRE                                       POST
    ----------------------                    ----------------------
    15kb file ->                              15kb file ->
              6200 -> 7400                              6400 -> 7950
       o=150  7000 -> 7800                       o=150  7200 -> 8200
                                              
    7kb file ->                               7kb file ->
              7500 -> 8550                              7450 -> 9150
       o=150  7650 -> 8700                       o=150  7850 -> 9250
                                              
                                              
    1kb file ->                               1kb file ->
              8100 -> 8750                              8100 -> 8750
       o=150  8400 -> 8800                       o=150  8550 -> 9000
                                              
    ----------------------                    ----------------------


## Overall effect of `Lwt_chan` fix #49 + buffer pools + last-chunk optimization
(only for files): compare figures at the top + those in POST to these for 2.6:


    2.6
    --------------

    404                                    16kb file ->
             11800                                   5500
     o=150   12500                            o=150  6100
                                           
    20-byte response                       15kb file ->  
              7450                                   5200
       o=150  7900                            o=150  5900
                                                         
                                           7kb file ->   
                                                     6000
                                              o=150  6700
                                                         
                                                         
                                           1kb file ->   
                                                     7650
                                              o=150  7950

