### PR TITLE
Log more details about SSL accept error

### DIFF
--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -992,6 +992,11 @@ let rec wait_connection use_ssl port socket =
            (fun e ->
               Ocsigen_messages.unexpected_exception e
                 "Server.wait_connection (handle connection)";
+              (match e with
+              | Ssl.Accept_error(Ssl.Error_ssl|Ssl.Error_syscall) ->
+                Ocsigen_messages.warning
+                  ("Last SSL error: " ^ Ssl.get_error_string ())
+              | _ -> ());
               return ())
          >>= fun () ->
          Lwt_log.ign_info ~section "** CLOSE";


### PR DESCRIPTION
Useful for distinguishing between the various SSL errors: unknown ca, no
shared cipher, unsupported protocol, etc.

If you have access to the client side then you can debug this with 'curl -v' or 'openssl s_client', however that is not always the case and server-side debugging is needed in some situations.