### PR TITLE
Add _opam in gitignore for OPAM 2.0 local switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ local/var/lib/ocsidb
 local/etc/ocsigenserver.conf
 local/etc/ocsigenserver.conf.opt
 doc/api-html
+_opam


### PR DESCRIPTION
OPAM 2.0 allows to have a local configuration and compiler (see https://opam.ocaml.org/blog/opam-2-0-preview/). This configuration is put in `_opam` directory.
Useful for people who wants to contribute to `ocsigenserver` without having to install all dependencies in another switch.
