### PR TITLE
Add prefix_and_path_of_t

### DIFF
--- a/src/baselib/ocsigen_lib.ml
+++ b/src/baselib/ocsigen_lib.ml
@@ -259,4 +259,20 @@ module Url = struct
 
   let split_path = Neturl.split_path
 
+  let prefix_and_path_of_t url =
+    let (https, host, port, _, path, _, _) = parse url in
+    let https_str = match https with
+    | None -> ""
+    | Some x -> if x then "https://" else "http://"
+    in
+    let host_str = match host with
+    | None -> ""
+    | Some x -> x
+    in
+    let port_str = match port with
+    | None -> ""
+    | Some x -> string_of_int x
+    in
+    (https_str ^ host_str ^ ":" ^ port_str, path)
+
 end

--- a/src/baselib/ocsigen_lib.mli
+++ b/src/baselib/ocsigen_lib.mli
@@ -78,4 +78,13 @@ module Url : sig
   (** alias of (Ocamlnet) [Neturl.split_path] *)
   val split_path : string -> string list
 
+  (** [prefix_and_path_of_t url] splits [url] in a couple [(prefix, path)] where
+      [prefix] is ["http(s)://host:port"] and [path] is the path as [string list]
+
+      Example: [prefix_and_path_of_t "http://ocsigen.org:80/tuto/manual"]
+      returns [("http://ocsigen.org:80", ["tuto", "manual"])].
+   *)
+  val prefix_and_path_of_t :
+    string ->
+    string * string list
 end


### PR DESCRIPTION
I don't know if there is an equivalent. I use it in OAuth2/OpenID Connect implementation in Ocsigen-start.