### PR TITLE
Do not use Camlp4 for baselib

### DIFF
--- a/Makefile.options
+++ b/Makefile.options
@@ -42,8 +42,6 @@ SERVER_PACKAGE := lwt.ssl           \
 	          tyxml.parser      \
                   dynlink           \
 
-SERVER_SYNTAX :=  tyxml.syntax lwt.syntax.log \
-
 INITPACKAGE := \"$(shell ${OCAMLFIND} query -p-format -recursive        \
 	                            -separator '\";\"' ${SERVER_PACKAGE})\"; \
 	       \"${PROJECTNAME}.commandline\";  \

--- a/opam
+++ b/opam
@@ -30,7 +30,6 @@ depends: [
   "tyxml" {> "3.6.0"}
   ("dbm" | "sqlite3" | "pgocaml")
   "ipaddr" {>= "2.1"}
-  "camlp4"
 ]
 depopts: "camlzip"
 conflicts: [

--- a/src/baselib/Makefile
+++ b/src/baselib/Makefile
@@ -10,8 +10,8 @@ PACKAGE  := \
 	tyxml \
 	lwt.syntax \
 	${LWT_PREEMPTIVE_PACKAGE} \
-	ipaddr \
-	${SERVER_SYNTAX} ## See ../../Makefile.options
+	ipaddr
+
 LIBS     := ${addprefix -package ,${PACKAGE}}
 OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
 OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
@@ -131,14 +131,14 @@ polytables.cmxa: polytables.cmx
 ##########
 
 %.cmi: %.mli
-	$(OCAMLC) -syntax camlp4o ${LIBS} -c $<
+	$(OCAMLC) ${LIBS} -c $<
 ${INTF_NOP4:.mli=.cmi}: \
 %.cmi: %.mli
 	$(OCAMLC) ${LIBS} -c $<
 %.cmo: %.ml
-	$(OCAMLC) -syntax camlp4o ${LIBS} -c $<
+	$(OCAMLC) ${LIBS} -c $<
 %.cmx: %.ml
-	$(OCAMLOPT) -syntax camlp4o ${LIBS} -c $<
+	$(OCAMLOPT) ${LIBS} -c $<
 %.cmxs: %.cmxa
 	$(OCAMLOPT) -shared -linkall -o $@ $<
 
@@ -156,7 +156,7 @@ distclean: clean
 ## Dependencies
 
 depend: ${PREDEP}
-	$(OCAMLDEP) ${LIBS} -syntax camlp4o $(filter-out ${INTF_NOP4},$(wildcard *.mli)) *.ml > .depend
+	$(OCAMLDEP) ${LIBS} $(filter-out ${INTF_NOP4},$(wildcard *.mli)) *.ml > .depend
 	$(OCAMLDEP) ${LIBS} ${INTF_NOP4} >> .depend
 
 FORCE:

--- a/src/baselib/ocsigen_lib_base.ml
+++ b/src/baselib/ocsigen_lib_base.ml
@@ -77,7 +77,7 @@ module Option = struct
     | Some v -> [v]
   module Lwt = struct
     let map f = function
-      | Some x -> lwt v = f x in Lwt.return (Some v)
+      | Some x -> f x >>= fun v -> Lwt.return (Some v)
       | None -> Lwt.return None
     let get f = function
       | Some x -> Lwt.return x

--- a/src/baselib/ocsigen_messages.ml
+++ b/src/baselib/ocsigen_messages.ml
@@ -53,18 +53,21 @@ let open_files ?(user = Ocsigen_config.get_user ()) ?(group = Ocsigen_config.get
 
     let open_log path =
       let path = full_path path in
-      try_lwt
-        Lwt_log.file path ()
-      with
-      | Unix.Unix_error(error,_,_) ->
-        raise_lwt (Ocsigen_config.Config_file_error (
-            Printf.sprintf "can't open log file %s: %s"
-              path (Unix.error_message error)))
+      Lwt.catch
+        (fun () -> Lwt_log.file path ())
+        (function
+          | Unix.Unix_error (error, _, _) ->
+            Lwt.fail
+              (Ocsigen_config.Config_file_error
+                 (Printf.sprintf "can't open log file %s: %s"
+                    path (Unix.error_message error)))
+          | exn ->
+            Lwt.fail exn)
     in
 
-    lwt acc = open_log access_file in
-    lwt war = open_log  warning_file in
-    lwt err = open_log  error_file in
+    open_log access_file >>= fun acc ->
+    open_log warning_file >>= fun war ->
+    open_log error_file >>= fun err ->
     loggers := [acc; war; err];
 
     Lwt_log.default :=
@@ -100,11 +103,9 @@ let open_files ?(user = Ocsigen_config.get_user ()) ?(group = Ocsigen_config.get
                         (Unix.getpwnam user).Unix.pw_uid
                       with Not_found as e -> ignore (Lwt_log.error "Error: Wrong user"); raise e)
     in
-    lwt () = Lwt_unix.chown (full_path access_file) uid gid in
-    lwt () = Lwt_unix.chown (full_path warning_file) uid gid in
-    lwt () = Lwt_unix.chown (full_path error_file) uid gid in
-
-    Lwt.return ()
+    Lwt_unix.chown (full_path access_file) uid gid >>= fun () ->
+    Lwt_unix.chown (full_path warning_file) uid gid >>= fun () ->
+    Lwt_unix.chown (full_path error_file) uid gid
 
 (****)
 

--- a/src/extensions/Makefile
+++ b/src/extensions/Makefile
@@ -8,8 +8,7 @@ PACKAGE  :=		\
 	lwt.react	\
 	netstring	\
 	netstring-pcre	\
-	tyxml.parser	\
-	${SERVER_SYNTAX} ## See ../../Makefile.options
+	tyxml.parser
 
 LIBS     := -I ../baselib -I ../http -I ../server ${addprefix -package ,${PACKAGE}}
 OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG}

--- a/src/http/Makefile
+++ b/src/http/Makefile
@@ -4,8 +4,7 @@ PACKAGE  := \
 	netstring \
 	netstring-pcre \
 	lwt.ssl \
-	tyxml \
-	${SERVER_SYNTAX} ## See ../../Makefile.options
+	tyxml
 
 LIBS     := -I ../baselib ${addprefix -package ,${PACKAGE}}
 OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG}

--- a/src/server/Makefile
+++ b/src/server/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.config
 
 all: byte opt
 
-PACKAGE  := ${SERVER_PACKAGE} ${SERVER_SYNTAX} ## See ../../Makefile.options
+PACKAGE  := ${SERVER_PACKAGE} ## See ../../Makefile.options
 LIBS     := -I ../baselib -I ../http ${addprefix -package ,${PACKAGE}} -I .
 OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
 OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}


### PR DESCRIPTION
This eliminates the use of Camlp4 for the standard library. Still needed for Ocsipersist, but this will be separated-out.

We use Camlp4 so little that I didn't even deem it necessary to use PPX instead.