### PR TITLE
Pass -thread flag

### DIFF
--- a/src/extensions/Makefile
+++ b/src/extensions/Makefile
@@ -11,8 +11,8 @@ PACKAGE  :=		\
 	tyxml.parser
 
 LIBS     := -I ../baselib -I ../http -I ../server ${addprefix -package ,${PACKAGE}}
-OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG}
-OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG}
+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
 OCAMLDOC := $(OCAMLFIND) ocamldoc
 OCAMLDEP := $(OCAMLFIND) ocamldep
 

--- a/src/http/Makefile
+++ b/src/http/Makefile
@@ -7,8 +7,8 @@ PACKAGE  := \
 	tyxml
 
 LIBS     := -I ../baselib ${addprefix -package ,${PACKAGE}}
-OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG}
-OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG}
+OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
+OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
 OCAMLDOC := $(OCAMLFIND) ocamldoc
 OCAMLDEP := $(OCAMLFIND) ocamldep
 


### PR DESCRIPTION
`lwt.preemptive` and `lwt.unix` have been merged, with the new package depending on `threads`. We thus need to compile with `-threads`.