### PR TITLE
Remove any uses of camlp4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements:
 
 Compilers:
 
- * ocaml and camlp4  (need version >= 3.12.1)
+ * ocaml             (need version >= 3.12.1)
  * a C compiler      (tested with gcc-4.4.5)
 
 Libraries:

--- a/opam
+++ b/opam
@@ -57,7 +57,6 @@ depends: [
   "tyxml" {>= "4.0.0"}
   ("dbm" | "sqlite3" | "pgocaml")
   "ipaddr" {>= "2.1"}
-  "camlp4"
 ]
 depopts: "camlzip"
 conflicts: [

--- a/src/extensions/ocsipersist-pgsql/Makefile
+++ b/src/extensions/ocsipersist-pgsql/Makefile
@@ -1,6 +1,6 @@
 include ../../../Makefile.config
 
-PACKAGE  := tyxml.parser pgocaml.syntax lwt.syntax
+PACKAGE  := tyxml.parser pgocaml lwt
 
 LIBS     := -I ../../baselib -I ../../http -I ../../server \
 	    ${addprefix -package ,${PACKAGE}}
@@ -40,14 +40,12 @@ ocsipersist.mli:
 
 ##########
 
-SYNTAX_FLAGS=-syntax camlp4o
-
 %.cmi: %.mli
 	$(OCAMLC) ${LIBS} -c $<
 %.cmo: %.ml
-	$(OCAMLC) ${LIBS} ${SYNTAX_FLAGS} -c $<
+	$(OCAMLC) ${LIBS} -c $<
 %.cmx: %.ml
-	$(OCAMLOPT) ${LIBS} ${SYNTAX_FLAGS} -c $<
+	$(OCAMLOPT) ${LIBS} -c $<
 %.cmxs: %.cmxa
 	$(OCAMLOPT) -shared -linkall -o $@ $<
 
@@ -63,7 +61,7 @@ distclean: clean
 ## Dependencies
 
 depend: ${PREDEP}
-	$(OCAMLDEP) ${LIBS} ${SYNTAX_FLAGS} *.mli *.ml > .depend
+	$(OCAMLDEP) ${LIBS} *.mli *.ml > .depend
 
 FORCE:
 -include .depend


### PR DESCRIPTION
camlp4 is a deprecated tool and should be avoided. This PR remove any remaining uses of camlp4 in ocsigenserver.