### PR TITLE
Compile with -safe-string (OCaml 4.06)

### DIFF
--- a/src/baselib/.depend
+++ b/src/baselib/.depend
@@ -1,10 +1,3 @@
-ocsigen_loader.cmi :
-ocsigen_cache.cmi :
-ocsigen_stream.cmi :
-ocsigen_config.cmi : ocsigen_lib.cmi
-ocsigen_messages.cmi :
-ocsigen_getcommandline.cmi :
-polytables.cmi :
 dynlink_wrapper.cmo :
 dynlink_wrapper.cmx :
 dynlink_wrapper.natdynlink.cmo :
@@ -13,23 +6,30 @@ dynlink_wrapper.nonatdynlink.cmo :
 dynlink_wrapper.nonatdynlink.cmx :
 ocsigen_cache.cmo : ocsigen_cache.cmi
 ocsigen_cache.cmx : ocsigen_cache.cmi
+ocsigen_cache.cmi :
 ocsigen_commandline.cmo : ocsigen_getcommandline.cmi ocsigen_config.cmi
 ocsigen_commandline.cmx : ocsigen_getcommandline.cmi ocsigen_config.cmx
 ocsigen_config.cmo : ocsigen_lib.cmi ocsigen_config.cmi
 ocsigen_config.cmx : ocsigen_lib.cmx ocsigen_config.cmi
-ocsigen_lib_base.cmo : ocsigen_lib_base.cmi
-ocsigen_lib_base.cmx : ocsigen_lib_base.cmi
+ocsigen_config.cmi : ocsigen_lib.cmi
+ocsigen_getcommandline.cmi :
 ocsigen_lib.cmo : ocsigen_lib_base.cmi ocsigen_lib.cmi
 ocsigen_lib.cmx : ocsigen_lib_base.cmx ocsigen_lib.cmi
+ocsigen_lib_base.cmo : ocsigen_lib_base.cmi
+ocsigen_lib_base.cmx : ocsigen_lib_base.cmi
 ocsigen_loader.cmo : ocsigen_lib.cmi ocsigen_config.cmi dynlink_wrapper.cmo \
     ocsigen_loader.cmi
 ocsigen_loader.cmx : ocsigen_lib.cmx ocsigen_config.cmx dynlink_wrapper.cmx \
     ocsigen_loader.cmi
+ocsigen_loader.cmi :
 ocsigen_messages.cmo : ocsigen_config.cmi ocsigen_messages.cmi
 ocsigen_messages.cmx : ocsigen_config.cmx ocsigen_messages.cmi
+ocsigen_messages.cmi :
 ocsigen_stream.cmo : ocsigen_lib.cmi ocsigen_config.cmi ocsigen_stream.cmi
 ocsigen_stream.cmx : ocsigen_lib.cmx ocsigen_config.cmx ocsigen_stream.cmi
+ocsigen_stream.cmi :
 polytables.cmo : polytables.cmi
 polytables.cmx : polytables.cmi
-ocsigen_lib_base.cmi :
+polytables.cmi :
 ocsigen_lib.cmi : ocsigen_lib_base.cmi
+ocsigen_lib_base.cmi :

--- a/src/baselib/Makefile
+++ b/src/baselib/Makefile
@@ -12,8 +12,12 @@ PACKAGE  := \
 	ipaddr
 
 LIBS     := ${addprefix -package ,${PACKAGE}}
-OCAMLC   := $(OCAMLFIND) ocamlc ${BYTEDBG} ${THREAD}
-OCAMLOPT := $(OCAMLFIND) ocamlopt ${OPTDBG} ${THREAD}
+# -no-keep-locs is needed since OCaml 4.06. If we don't compile with
+# -no-keep-locs, the .cmi's of the different ocsigen_*commandline will
+# be incompatible with each other leading to a compilation failure
+# later.
+OCAMLC   := $(OCAMLFIND) ocamlc -no-keep-locs ${BYTEDBG} ${THREAD}
+OCAMLOPT := $(OCAMLFIND) ocamlopt -no-keep-locs ${OPTDBG} ${THREAD}
 OCAMLDOC := $(OCAMLFIND) ocamldoc
 OCAMLDEP := $(OCAMLFIND) ocamldep
 

--- a/src/baselib/ocsigen_stream.ml
+++ b/src/baselib/ocsigen_stream.ml
@@ -183,7 +183,7 @@ let rec skip s k = match s with
     let len = String.length s in
     let len64 = Int64.of_int len in
     if Int64.compare k len64 <= 0
-    then 
+    then
       let k = Int64.to_int k in
       Lwt.return (Cont (String.sub s k (len - k), f))
     else (enlarge_stream (Cont ("", f)) >>=
@@ -211,7 +211,7 @@ let substream delim s =
           with Not_found ->
             let pos = (len + 1 - ldelim) in
             cont (String.sub s 0 pos)
-              (fun () -> 
+              (fun () ->
                  next f >>= function
                  | Finished _ -> Lwt.fail Stream_too_small
                  | Cont (s', f') ->
@@ -236,7 +236,7 @@ let of_file filename =
     if n = 0 then empty None else
       (* Streams should be immutable, thus we always make a copy
          of the buffer *)
-      cont (Bytes.sub buf 0 n) aux
+      cont (Bytes.sub_string buf 0 n) aux
   in make ~finalize:(fun _ -> Lwt_unix.close fd) aux
 
 let of_string s =

--- a/src/extensions/.depend
+++ b/src/extensions/.depend
@@ -1,7 +1,3 @@
-accesscontrol.cmi : ../server/ocsigen_extensions.cmi
-authbasic.cmi :
-ocsigen_comet.cmi : ../baselib/ocsigen_stream.cmi
-ocsipersist.cmi :
 accesscontrol.cmo : ../server/ocsigen_request_info.cmi \
     ../baselib/ocsigen_lib.cmi ../http/ocsigen_http_frame.cmi \
     ../server/ocsigen_extensions.cmi ../http/ocsigen_cookies.cmi \
@@ -10,12 +6,14 @@ accesscontrol.cmx : ../server/ocsigen_request_info.cmx \
     ../baselib/ocsigen_lib.cmx ../http/ocsigen_http_frame.cmx \
     ../server/ocsigen_extensions.cmx ../http/ocsigen_cookies.cmx \
     ../http/http_headers.cmx ../http/framepp.cmx accesscontrol.cmi
+accesscontrol.cmi : ../server/ocsigen_extensions.cmi
 authbasic.cmo : ../server/ocsigen_request_info.cmi \
     ../http/ocsigen_http_frame.cmi ../server/ocsigen_extensions.cmi \
     ../http/ocsigen_cookies.cmi ../http/http_headers.cmi authbasic.cmi
 authbasic.cmx : ../server/ocsigen_request_info.cmx \
     ../http/ocsigen_http_frame.cmx ../server/ocsigen_extensions.cmx \
     ../http/ocsigen_cookies.cmx ../http/http_headers.cmx authbasic.cmi
+authbasic.cmi :
 cgimod.cmo : ../baselib/ocsigen_stream.cmi ../http/ocsigen_senders.cmi \
     ../server/ocsigen_request_info.cmi ../baselib/ocsigen_lib.cmi \
     ../http/ocsigen_http_frame.cmi ../http/ocsigen_http_com.cmi \
@@ -35,13 +33,13 @@ cors.cmx : ../server/ocsigen_request_info.cmx ../baselib/ocsigen_lib.cmx \
     ../http/ocsigen_http_frame.cmx ../server/ocsigen_extensions.cmx \
     ../http/http_headers.cmx ../http/framepp.cmx
 deflatemod.cmo : ../baselib/ocsigen_stream.cmi \
-    ../server/ocsigen_request_info.cmi ../http/ocsigen_http_frame.cmi \
-    ../http/ocsigen_headers.cmi ../server/ocsigen_extensions.cmi \
-    ../http/http_headers.cmi
+    ../server/ocsigen_request_info.cmi ../baselib/ocsigen_lib.cmi \
+    ../http/ocsigen_http_frame.cmi ../http/ocsigen_headers.cmi \
+    ../server/ocsigen_extensions.cmi ../http/http_headers.cmi
 deflatemod.cmx : ../baselib/ocsigen_stream.cmx \
-    ../server/ocsigen_request_info.cmx ../http/ocsigen_http_frame.cmx \
-    ../http/ocsigen_headers.cmx ../server/ocsigen_extensions.cmx \
-    ../http/http_headers.cmx
+    ../server/ocsigen_request_info.cmx ../baselib/ocsigen_lib.cmx \
+    ../http/ocsigen_http_frame.cmx ../http/ocsigen_headers.cmx \
+    ../server/ocsigen_extensions.cmx ../http/http_headers.cmx
 extendconfiguration.cmo : ../server/ocsigen_parseconfig.cmi \
     ../server/ocsigen_extensions.cmi ../http/ocsigen_cookies.cmi \
     ../baselib/ocsigen_config.cmi ../http/ocsigen_charset_mime.cmi
@@ -60,6 +58,8 @@ ocsigen_comet.cmx : ../baselib/ocsigen_stream.cmx \
     ../server/ocsigen_request_info.cmx ../baselib/ocsigen_lib.cmx \
     ../http/ocsigen_http_frame.cmx ../server/ocsigen_extensions.cmx \
     ../baselib/ocsigen_config.cmx ocsigen_comet.cmi
+ocsigen_comet.cmi : ../baselib/ocsigen_stream.cmi
+ocsipersist.cmi :
 outputfilter.cmo : ../http/ocsigen_http_frame.cmi \
     ../http/ocsigen_headers.cmi ../server/ocsigen_extensions.cmi \
     ../http/http_headers.cmi

--- a/src/extensions/ocsipersist-dbm/.depend
+++ b/src/extensions/ocsipersist-dbm/.depend
@@ -1,10 +1,10 @@
-ocsidbmtypes.cmi :
-ocsipersist.cmi :
 ocsidbm.cmo : ocsidbmtypes.cmi
 ocsidbm.cmx : ocsidbmtypes.cmi
+ocsidbmtypes.cmi :
 ocsipersist.cmo : ../../baselib/ocsigen_messages.cmi \
     ../../server/ocsigen_extensions.cmi ../../baselib/ocsigen_config.cmi \
     ocsidbmtypes.cmi ocsipersist.cmi
 ocsipersist.cmx : ../../baselib/ocsigen_messages.cmx \
     ../../server/ocsigen_extensions.cmx ../../baselib/ocsigen_config.cmx \
     ocsidbmtypes.cmi ocsipersist.cmi
+ocsipersist.cmi :

--- a/src/extensions/ocsipersist-pgsql/.depend
+++ b/src/extensions/ocsipersist-pgsql/.depend
@@ -1,3 +1,3 @@
-ocsipersist.cmi :
 ocsipersist.cmo : ../../server/ocsigen_extensions.cmi ocsipersist.cmi
 ocsipersist.cmx : ../../server/ocsigen_extensions.cmx ocsipersist.cmi
+ocsipersist.cmi :

--- a/src/extensions/ocsipersist-sqlite/.depend
+++ b/src/extensions/ocsipersist-sqlite/.depend
@@ -1,7 +1,7 @@
-ocsipersist.cmi :
 ocsipersist.cmo : ../../baselib/ocsigen_messages.cmi \
     ../../server/ocsigen_extensions.cmi ../../baselib/ocsigen_config.cmi \
     ocsipersist.cmi
 ocsipersist.cmx : ../../baselib/ocsigen_messages.cmx \
     ../../server/ocsigen_extensions.cmx ../../baselib/ocsigen_config.cmx \
     ocsipersist.cmi
+ocsipersist.cmi :

--- a/src/http/.depend
+++ b/src/http/.depend
@@ -1,39 +1,32 @@
-framepp.cmi : ocsigen_http_frame.cmi
-http_headers.cmi :
-multipart.cmi : ../baselib/ocsigen_stream.cmi
-ocsigen_charset_mime.cmi :
-ocsigen_cookies.cmi : ../baselib/ocsigen_lib.cmi
-ocsigen_headers.cmi : ../baselib/ocsigen_lib.cmi ocsigen_http_frame.cmi \
-    ocsigen_cookies.cmi
-ocsigen_http_com.cmi : ../baselib/ocsigen_stream.cmi ocsigen_http_frame.cmi \
-    http_headers.cmi
-ocsigen_http_frame.cmi : ../baselib/ocsigen_stream.cmi \
-    ../baselib/ocsigen_lib.cmi ocsigen_cookies.cmi http_headers.cmi
-ocsigen_senders.cmi : ../baselib/ocsigen_stream.cmi ocsigen_http_frame.cmi \
-    ocsigen_http_com.cmi ocsigen_cookies.cmi ocsigen_charset_mime.cmi \
-    http_headers.cmi
 framepp.cmo : ocsigen_http_frame.cmi http_headers.cmi framepp.cmi
 framepp.cmx : ocsigen_http_frame.cmx http_headers.cmx framepp.cmi
+framepp.cmi : ocsigen_http_frame.cmi
 http_headers.cmo : http_headers.cmi
 http_headers.cmx : http_headers.cmi
+http_headers.cmi :
 http_lexer.cmo : ocsigen_http_frame.cmi http_headers.cmi
 http_lexer.cmx : ocsigen_http_frame.cmx http_headers.cmx
 multipart.cmo : ../baselib/ocsigen_stream.cmi ../baselib/ocsigen_lib.cmi \
     multipart.cmi
 multipart.cmx : ../baselib/ocsigen_stream.cmx ../baselib/ocsigen_lib.cmx \
     multipart.cmi
+multipart.cmi : ../baselib/ocsigen_stream.cmi
 ocsigen_charset_mime.cmo : ../baselib/ocsigen_lib.cmi \
     ../baselib/ocsigen_config.cmi ocsigen_charset_mime.cmi
 ocsigen_charset_mime.cmx : ../baselib/ocsigen_lib.cmx \
     ../baselib/ocsigen_config.cmx ocsigen_charset_mime.cmi
+ocsigen_charset_mime.cmi :
 ocsigen_cookies.cmo : ocsigen_cookies.cmi
 ocsigen_cookies.cmx : ocsigen_cookies.cmi
+ocsigen_cookies.cmi : ../baselib/ocsigen_lib.cmi
 ocsigen_headers.cmo : ocsigen_senders.cmi ../baselib/ocsigen_lib.cmi \
     ocsigen_http_frame.cmi ocsigen_cookies.cmi http_headers.cmi \
     ocsigen_headers.cmi
 ocsigen_headers.cmx : ocsigen_senders.cmx ../baselib/ocsigen_lib.cmx \
     ocsigen_http_frame.cmx ocsigen_cookies.cmx http_headers.cmx \
     ocsigen_headers.cmi
+ocsigen_headers.cmi : ../baselib/ocsigen_lib.cmi ocsigen_http_frame.cmi \
+    ocsigen_cookies.cmi
 ocsigen_http_com.cmo : ../baselib/ocsigen_stream.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_http_frame.cmi ocsigen_cookies.cmi \
     ../baselib/ocsigen_config.cmi http_lexer.cmo http_headers.cmi framepp.cmi \
@@ -42,12 +35,16 @@ ocsigen_http_com.cmx : ../baselib/ocsigen_stream.cmx \
     ../baselib/ocsigen_lib.cmx ocsigen_http_frame.cmx ocsigen_cookies.cmx \
     ../baselib/ocsigen_config.cmx http_lexer.cmx http_headers.cmx framepp.cmx \
     ocsigen_http_com.cmi
+ocsigen_http_com.cmi : ../baselib/ocsigen_stream.cmi ocsigen_http_frame.cmi \
+    http_headers.cmi
 ocsigen_http_frame.cmo : ../baselib/ocsigen_stream.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_cookies.cmi http_headers.cmi \
     ocsigen_http_frame.cmi
 ocsigen_http_frame.cmx : ../baselib/ocsigen_stream.cmx \
     ../baselib/ocsigen_lib.cmx ocsigen_cookies.cmx http_headers.cmx \
     ocsigen_http_frame.cmi
+ocsigen_http_frame.cmi : ../baselib/ocsigen_stream.cmi \
+    ../baselib/ocsigen_lib.cmi ocsigen_cookies.cmi http_headers.cmi
 ocsigen_senders.cmo : ../baselib/ocsigen_stream.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_http_frame.cmi ocsigen_http_com.cmi \
     ocsigen_cookies.cmi ../baselib/ocsigen_config.cmi \
@@ -56,6 +53,9 @@ ocsigen_senders.cmx : ../baselib/ocsigen_stream.cmx \
     ../baselib/ocsigen_lib.cmx ocsigen_http_frame.cmx ocsigen_http_com.cmx \
     ocsigen_cookies.cmx ../baselib/ocsigen_config.cmx \
     ocsigen_charset_mime.cmx http_headers.cmx ocsigen_senders.cmi
+ocsigen_senders.cmi : ../baselib/ocsigen_stream.cmi ocsigen_http_frame.cmi \
+    ocsigen_http_com.cmi ocsigen_cookies.cmi ocsigen_charset_mime.cmi \
+    http_headers.cmi
 test_parser.cmo : ocsigen_http_frame.cmi http_lexer.cmo
 test_parser.cmx : ocsigen_http_frame.cmx http_lexer.cmx
 test_pp.cmo : ocsigen_http_frame.cmi framepp.cmi

--- a/src/http/ocsigen_senders.ml
+++ b/src/http/ocsigen_senders.ml
@@ -237,8 +237,9 @@ struct
         Ocsigen_stream.empty None
       else begin
         if read = buffer_size
-        then Ocsigen_stream.cont buf read_aux
-        else Ocsigen_stream.cont (String.sub buf 0 read) read_aux
+        then Ocsigen_stream.cont (Bytes.to_string buf) read_aux
+        (* copying :( *)
+        else Ocsigen_stream.cont (Bytes.sub_string buf 0 read) read_aux
       end
     in read_aux
 

--- a/src/server/.depend
+++ b/src/server/.depend
@@ -1,25 +1,8 @@
+ocsigen_command.cmo : ../baselib/ocsigen_messages.cmi ocsigen_command.cmi
+ocsigen_command.cmx : ../baselib/ocsigen_messages.cmx ocsigen_command.cmi
 ocsigen_command.cmi :
 ocsigen_common_server.cmi : ocsigen_request_info.cmi \
     ../http/ocsigen_http_frame.cmi ../http/ocsigen_cookies.cmi
-ocsigen_extensions.cmi : ocsigen_request_info.cmi ../baselib/ocsigen_lib.cmi \
-    ../http/ocsigen_http_frame.cmi ../http/ocsigen_http_com.cmi \
-    ../http/ocsigen_cookies.cmi ocsigen_command.cmi \
-    ../http/ocsigen_charset_mime.cmi
-ocsigen_http_client.cmi : ../baselib/ocsigen_stream.cmi \
-    ../http/ocsigen_http_frame.cmi ocsigen_extensions.cmi \
-    ../http/http_headers.cmi
-ocsigen_local_files.cmi : ../http/ocsigen_http_frame.cmi \
-    ocsigen_extensions.cmi
-ocsigen_parseconfig.cmi : ocsigen_socket.cmi ocsigen_extensions.cmi
-ocsigen_range.cmi : ocsigen_request_info.cmi ../http/ocsigen_http_frame.cmi
-ocsigen_request_info.cmi : ../baselib/polytables.cmi \
-    ../baselib/ocsigen_lib.cmi ../http/ocsigen_http_frame.cmi \
-    ../http/ocsigen_http_com.cmi ../http/ocsigen_cookies.cmi \
-    ../http/http_headers.cmi
-ocsigen_server.cmi :
-ocsigen_socket.cmi :
-ocsigen_command.cmo : ../baselib/ocsigen_messages.cmi ocsigen_command.cmi
-ocsigen_command.cmx : ../baselib/ocsigen_messages.cmx ocsigen_command.cmi
 ocsigen_extensions.cmo : ocsigen_request_info.cmi \
     ../baselib/ocsigen_loader.cmi ../baselib/ocsigen_lib.cmi \
     ../http/ocsigen_http_frame.cmi ../http/ocsigen_http_com.cmi \
@@ -32,6 +15,10 @@ ocsigen_extensions.cmx : ocsigen_request_info.cmx \
     ../http/ocsigen_cookies.cmx ../baselib/ocsigen_config.cmx \
     ocsigen_command.cmx ../http/ocsigen_charset_mime.cmx \
     ocsigen_extensions.cmi
+ocsigen_extensions.cmi : ocsigen_request_info.cmi ../baselib/ocsigen_lib.cmi \
+    ../http/ocsigen_http_frame.cmi ../http/ocsigen_http_com.cmi \
+    ../http/ocsigen_cookies.cmi ocsigen_command.cmi \
+    ../http/ocsigen_charset_mime.cmi
 ocsigen_http_client.cmo : ../baselib/ocsigen_stream.cmi \
     ../http/ocsigen_senders.cmi ../baselib/ocsigen_lib.cmi \
     ../http/ocsigen_http_frame.cmi ../http/ocsigen_http_com.cmi \
@@ -44,12 +31,17 @@ ocsigen_http_client.cmx : ../baselib/ocsigen_stream.cmx \
     ../http/ocsigen_headers.cmx ocsigen_extensions.cmx \
     ../baselib/ocsigen_config.cmx ../http/http_headers.cmx \
     ocsigen_http_client.cmi
+ocsigen_http_client.cmi : ../baselib/ocsigen_stream.cmi \
+    ../http/ocsigen_http_frame.cmi ocsigen_extensions.cmi \
+    ../http/http_headers.cmi
 ocsigen_local_files.cmo : ../http/ocsigen_senders.cmi \
     ocsigen_request_info.cmi ocsigen_extensions.cmi \
     ../baselib/ocsigen_config.cmi ocsigen_local_files.cmi
 ocsigen_local_files.cmx : ../http/ocsigen_senders.cmx \
     ocsigen_request_info.cmx ocsigen_extensions.cmx \
     ../baselib/ocsigen_config.cmx ocsigen_local_files.cmi
+ocsigen_local_files.cmi : ../http/ocsigen_http_frame.cmi \
+    ocsigen_extensions.cmi
 ocsigen_parseconfig.cmo : ocsigen_socket.cmi ../baselib/ocsigen_loader.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_extensions.cmi \
     ../baselib/ocsigen_config.cmi ../http/ocsigen_charset_mime.cmi \
@@ -58,6 +50,7 @@ ocsigen_parseconfig.cmx : ocsigen_socket.cmx ../baselib/ocsigen_loader.cmx \
     ../baselib/ocsigen_lib.cmx ocsigen_extensions.cmx \
     ../baselib/ocsigen_config.cmx ../http/ocsigen_charset_mime.cmx \
     ocsigen_parseconfig.cmi
+ocsigen_parseconfig.cmi : ocsigen_socket.cmi ocsigen_extensions.cmi
 ocsigen_range.cmo : ../baselib/ocsigen_stream.cmi ocsigen_request_info.cmi \
     ../baselib/ocsigen_lib.cmi ../http/ocsigen_http_frame.cmi \
     ocsigen_extensions.cmi ../baselib/ocsigen_config.cmi \
@@ -66,6 +59,7 @@ ocsigen_range.cmx : ../baselib/ocsigen_stream.cmx ocsigen_request_info.cmx \
     ../baselib/ocsigen_lib.cmx ../http/ocsigen_http_frame.cmx \
     ocsigen_extensions.cmx ../baselib/ocsigen_config.cmx \
     ../http/http_headers.cmx ocsigen_range.cmi
+ocsigen_range.cmi : ocsigen_request_info.cmi ../http/ocsigen_http_frame.cmi
 ocsigen_request_info.cmo : ../baselib/polytables.cmi \
     ../baselib/ocsigen_lib.cmi ../http/ocsigen_http_frame.cmi \
     ../http/ocsigen_http_com.cmi ../http/ocsigen_cookies.cmi \
@@ -74,6 +68,10 @@ ocsigen_request_info.cmx : ../baselib/polytables.cmx \
     ../baselib/ocsigen_lib.cmx ../http/ocsigen_http_frame.cmx \
     ../http/ocsigen_http_com.cmx ../http/ocsigen_cookies.cmx \
     ocsigen_request_info.cmi
+ocsigen_request_info.cmi : ../baselib/polytables.cmi \
+    ../baselib/ocsigen_lib.cmi ../http/ocsigen_http_frame.cmi \
+    ../http/ocsigen_http_com.cmi ../http/ocsigen_cookies.cmi \
+    ../http/http_headers.cmi
 ocsigen_server.cmo : ../baselib/polytables.cmi ../baselib/ocsigen_stream.cmi \
     ocsigen_socket.cmi ../http/ocsigen_senders.cmi ocsigen_request_info.cmi \
     ocsigen_range.cmi ocsigen_parseconfig.cmi ../baselib/ocsigen_messages.cmi \
@@ -96,9 +94,11 @@ ocsigen_server.cmx : ../baselib/polytables.cmx ../baselib/ocsigen_stream.cmx \
     ocsigen_command.cmx ../baselib/ocsigen_cache.cmx ../http/multipart.cmx \
     ../http/http_headers.cmx ../baselib/dynlink_wrapper.cmx \
     ocsigen_server.cmi
+ocsigen_server.cmi :
 ocsigen_socket.cmo : ../baselib/ocsigen_lib_base.cmi \
     ../baselib/ocsigen_lib.cmi ocsigen_socket.cmi
 ocsigen_socket.cmx : ../baselib/ocsigen_lib_base.cmx \
     ../baselib/ocsigen_lib.cmx ocsigen_socket.cmi
+ocsigen_socket.cmi :
 server_main.cmo : ocsigen_server.cmi
 server_main.cmx : ocsigen_server.cmx

--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -168,7 +168,7 @@ and find_post_params_multipart_form_data body_gen ctparams filenames
       return ()
     | A_File (_,_,_,wh,_) ->
       let len = String.length s in
-      let r = Unix.write wh s 0 len in
+      let r = Unix.write_substring wh s 0 len in
       if r < len then
         (*XXXX Inefficient if s is long *)
         add where (String.sub s r (len - r))
@@ -1422,7 +1422,7 @@ let start_server () =
           Unix.openfile
             p
             [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o640 in
-        ignore (Unix.write f spid 0 len);
+        ignore (Unix.write_substring f spid 0 len);
         Unix.close f
     in
 


### PR DESCRIPTION
Use immutable strings as much as possible. Some copying needed.

See discussion in #135.