### PR TITLE
Gracefully respond to invalid command line options.

### DIFF
--- a/src/baselib/ocsigen_commandline.ml
+++ b/src/baselib/ocsigen_commandline.ml
@@ -39,4 +39,6 @@ let cmdline : unit =
       ]
       (fun _ -> ())
       "usage: ocsigen [-c configfile]"
-  with Arg.Help s -> print_endline s; exit 0
+  with
+  | Arg.Help s -> print_string s; exit 0
+  | Arg.Bad s -> prerr_string s; exit 1


### PR DESCRIPTION
Handle the Arg.Bad exception and print command line usage to stderr.

Normalize the Arg.Help handler to omit an extra newline when printing
command line usage.