### PR TITLE
Add Ocsigen_getcommandline mli's to produce compatible cmi's

### DIFF
--- a/src/baselib/commandline/ocsigen_getcommandline.mli
+++ b/src/baselib/commandline/ocsigen_getcommandline.mli
@@ -1,0 +1,3 @@
+(** Contains the command line that will be parsed by the server
+    when Ocsigen_commandline is linked *)
+val commandline : string array

--- a/src/baselib/nocommandline/ocsigen_getcommandline.mli
+++ b/src/baselib/nocommandline/ocsigen_getcommandline.mli
@@ -1,0 +1,3 @@
+(** Contains the command line that will be parsed by the server
+    when Ocsigen_commandline is linked *)
+val commandline : string array


### PR DESCRIPTION
This fixes compilation with OCaml 4.07 .