### PR TITLE
Fix GitHub access token name in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ deploy:
   provider: pages
   keep-history: true
   skip-cleanup: true
-  github-token: $GITHUB_TOKEN
+  github-token: $GHP_TOKEN
   local-dir: _doc
   on:
     branch: wikidoc


### PR DESCRIPTION
Also @balat, please add the `GHP_TOKEN` on *travis-ci.org* instead of .com: https://travis-ci.org/ocsigen/ocsigenserver/settings