### PR TITLE
Add profiling flag to the config script and make it the default behaviour

### DIFF
--- a/Makefile.options
+++ b/Makefile.options
@@ -13,7 +13,7 @@ OPTDBG  += -bin-annot
 endif
 
 ifeq "$(PROFILING)" "YES"
-BYTEDBG := -p ${BYTEDBG}
+BYTEDBG := ${BYTEDBG}
 OPTDBG  += -p
 endif
 

--- a/configure
+++ b/configure
@@ -77,6 +77,7 @@ set_defaults () {
     enable_natdynlink=1
     enable_debug=1
     enable_annot=1
+		enable_profiling=0
     with_sqlite=1
     with_pgsql=1
     with_camlzip=1
@@ -106,7 +107,7 @@ full_pwd=`pwd`
 ## Option parsing
 
 ## Which options exist? eoptions for enable/disable, woptions for with/without:
-eoptions="debug annot natdynlink"
+eoptions="debug annot profiling natdynlink"
 woptions="pgsql sqlite dbm camlzip"
 
 print_options () {
@@ -181,6 +182,7 @@ usage: ./configure [ options ]
 
   --enable-debug,	--disable-debug		Enable/disable debug output
   --enable-annot,	--disable-annot		Enable/disable .cmt{,i} files generation
+  --enable-profiling,	--disable-profiling	Enable/disable profiling
   --enable-natdynlink,	--disable-natdynlink	Enable/disable nativecode dynamic linking
 
   --with-sqlite,	--without-sqlite	Compile ocsipersist with SQLite for persistent storage
@@ -491,6 +493,11 @@ if [ $enable_annot -gt 0 ] ; then
 else
 	enable_annot="NO"
 fi
+if [ $enable_profiling -gt 0 ] ; then
+	enable_profiling="YES"
+else
+	enable_profiling="NO"
+fi
 if [ $enable_natdynlink -gt 0 ] ; then
 	enable_natdynlink="YES"
 else
@@ -574,7 +581,7 @@ DEBUG:=$enable_debug
 ANNOT:=$enable_annot
 
 # Profiling (always put NO here - but if you want to debug ocsigen):
-PROFILING:=NO
+PROFILING:=$enable_profiling
 
 
 

--- a/opam
+++ b/opam
@@ -13,6 +13,7 @@ build: [
   [
     "sh"
     "configure"
+    "--enable-profiling"
     "--prefix"
     "%{prefix}%"
     "--ocsigen-user"

--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -47,6 +47,9 @@ let () = Ocsigen_commandline.cmdline
    an exception ... *)
 let _ = Sys.set_signal Sys.sigpipe Sys.Signal_ignore
 
+(* Exit gracefully on SIGINT so that profiling will work *)
+let _ = Sys.set_signal Sys.sigint (Sys.Signal_handle(fun _ -> exit 0))
+
 let section = Lwt_log.Section.make "ocsigen:main"
 
 (* Initialize exception handler for Lwt timeouts: *)


### PR DESCRIPTION
Amend the build process and add SIGINT handling (`gmon.out` is only written if the process exits normally).