### PR TITLE
fix lwt.react in META.in file

### DIFF
--- a/src/files/META.in
+++ b/src/files/META.in
@@ -188,7 +188,7 @@ package "ext" (
 
   package "comet" (
     exists_if = "ocsigen_comet.cmo,ocsigen_comet.cmx"
-    requires = "ocsigenserver,lwt.react"
+    requires = "ocsigenserver,lwt_react"
     version = "[distributed with Ocsigen server]"
     description = "Comet server-to-client communication"
     archive(byte) = "ocsigen_comet.cmo"


### PR DESCRIPTION
This appears to be a minor issue that triggers a compilation error when using Dune on projects which depend on ocsigenserver.