### PR TITLE
Fixing typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -134,7 +134,7 @@
   * Split the ocsigen package in three : tyxml, ocsigenserver and eliom
   * Rename into ocsigenserver
   * Revproxy, Accesscontrol: Handling {{{X-Forwarded-For}}} and {{{X-Forwarded-Proto}}} headers
-  * HTTP parser rewrited
+  * HTTP parser rewritten
 
 ===== 1.90 =====
 
@@ -465,7 +465,7 @@
        browsers).
     ** Eliom: More secure cookies.
     ** Eliom: new version of the tutorial.
-    ** Eliom splitted in several modules.
+    ** Eliom split in several modules.
     ** Eliom: Nurpawiki example now called Miniwiki.
     ** Eliom: {{{any_...}}} form widgets now called {{{raw_...}}}
     ** Eliom: {{{~url}}} parameter (for {{{new_service}}}, etc.) now
@@ -565,11 +565,11 @@
     of type body content.
   * Eliom: Module {{{Text}}} replaced by {{{HtmlText}}}, and adding
     {{{CssText}}} and {{{Text}}} (for any content type).
-  * Eliom: Bugfix - Typing errors of parameters are now catched only
+  * Eliom: Bugfix - Typing errors of parameters are now caught only
     if the names of parameters fit exactly.
   * Eliom: {{{register_service}}} now called {{{register}}}.
   * Eliom: EXPERIMENTAL Fallbacks can now get a "Session expired" from
-    previous pages and actions may send informations to the page
+    previous pages and actions may send information to the page
     generated (using exception).
   * Eliom: Now possible to pre-apply services (to make links or to be
     used as fallbacks for coservices)
@@ -588,7 +588,7 @@
   * Ocsigen: Simplifying parsing of configuration file (could be
     improved).
   * Ocsigen: EXPERIMENTAL It is now possible to reload the modules
-    without stoping the server.
+    without stopping the server.
   * Staticmod: Rewriting of URLs using regular expressions.
 
 ===== 0.6.0 (2007-03-14) =====
@@ -679,7 +679,7 @@
     parameters. Note that {{{**}}} is used to create **pairs** and not
     tuples.
   * The {{{a}}} and {{{post_form}}} functions now take a fix number of
-    parameters, correponding to GET parameters.
+    parameters, corresponding to GET parameters.
   * //URLs// are now called //services//,
   * //state URLs// are now called //auxiliary services//,
   * {{{register_post_url}}} does not exist anymore. use

--- a/configure
+++ b/configure
@@ -545,7 +545,7 @@ CHMOD     := chmod
 INSTALL   := install
 CC        := gcc
 
-# optionnal
+# optional
 RLWRAP    := $rlwrap
 
 

--- a/src/baselib/ocsigen_lib_base.ml
+++ b/src/baselib/ocsigen_lib_base.ml
@@ -298,7 +298,7 @@ module String_base = struct
     with Invalid_argument _ -> raise Not_found
 
   (* Cut a string to the next separator, removing spaces.
-     Raises Not_found if the separator connot be found.
+     Raises Not_found if the separator cannot be found.
   *)
   let sep char s =
     let len = String.length s in

--- a/src/baselib/ocsigen_messages.ml
+++ b/src/baselib/ocsigen_messages.ml
@@ -172,7 +172,7 @@ reviewed the proposed library, it is next step.
 The four methods tested are: lazy, fun, ifprint, and fun moving the "if"
 to the caller (see full listing and results at the end of the post). Two
 test has been done for each one: when parameter is an integer constant
-and when parameter is the result of a funcion call who mades an addition.
+and when parameter is the result of a function call who mades an addition.
 
 The conclusion seems: defining that "lazy" method needs 1 unit of time,
 proposal using "fun" instead of lazy needs 0.8, and the version
@@ -180,7 +180,7 @@ proposal using "fun" instead of lazy needs 0.8, and the version
 
 Thus, if no error has been done, fun is the fastest option, lazy is near.
 
-Another point is the posibility of, using a camlp4 syntax extension, to
+Another point is the possibility of, using a camlp4 syntax extension, to
 introduce a few of sugar. Something like expand:
 
 from: log "some=%d\n" 14;

--- a/src/baselib/ocsigen_stream.mli
+++ b/src/baselib/ocsigen_stream.mli
@@ -62,7 +62,7 @@ val cont : 'a -> (unit -> 'a step Lwt.t) -> 'a step Lwt.t
     finalizers must be called manually. *)
 val add_finalizer : 'a t -> (outcome -> unit Lwt.t) -> unit
 
-(** Finalize the stream. This function must be called explicitely after reading
+(** Finalize the stream. This function must be called explicitly after reading
     the stream, otherwise finalizers won't be called. *)
 val finalize : 'a t -> outcome -> unit Lwt.t
 

--- a/src/extensions/cgimod.ml
+++ b/src/extensions/cgimod.ml
@@ -58,7 +58,7 @@ type reg = {
   path: string; (** path of the script *)
   path_info: string; (** path_info environment variable *)
 
-  exec:string option; (** binary to execute the script with (optionnal) *)
+  exec:string option; (** binary to execute the script with (optional) *)
   env:(string * string) list (** environment variables *) }
 
 (*****************************************************************************)
@@ -121,7 +121,7 @@ let string_conform2 s =
 (* split a string in two parts, according to a regexp *)
 let split_regexp r s =
   match Regexp.string_match r s 0 with
-  | None -> None (* the begining of the string doesn't match the regexp *)
+  | None -> None (* the beginning of the string doesn't match the regexp *)
   | Some result ->
     let (split,l) = Regexp.match_end result, String.length s in
     let s' = Regexp.first_chars s split in

--- a/src/extensions/deflatemod.ml
+++ b/src/extensions/deflatemod.ml
@@ -238,7 +238,7 @@ let convert = function
   |(None,v) -> Some (Star, qvalue v)
   |_ -> None
 
-(* Follow http's RFC to select the transfert encoding *)
+(* Follow http's RFC to select the transfer encoding *)
 let select_encoding accept_header =
   let h = List.sort enc_compare (filtermap convert accept_header) in
   let (exclude,accept) =

--- a/src/extensions/ocsigen_comet.ml
+++ b/src/extensions/ocsigen_comet.ml
@@ -46,7 +46,7 @@ let map_rev_accu_split func lst accu1 accu2 =
 (*** EXTENSION OPTIONS ***)
 
 
-(* timeout for comet connections : if no value has been written in the ellapsed
+(* timeout for comet connections : if no value has been written in the elapsed
  * time, connection will be closed. Should be equal to client timeout. *)
 let timeout_ref = ref 20.
 let get_timeout () = !timeout_ref
@@ -128,7 +128,7 @@ end = struct
   let new_id = Ocsigen_lib.make_cryptographic_safe_string
 
   (* because Hashtables allow search for elements with a corresponding hash, we
-   * have to create a dummy channel in order to retreive the original channel.
+   * have to create a dummy channel in order to retrieve the original channel.
    * Is there a KISSer way to do that ? *)
   let (dummy1, dummy2) = Lwt.task ()
   let dummy_chan i =
@@ -212,7 +212,7 @@ sig
 
   val decode_upcomming :
     Ocsigen_extensions.request -> (Channels.t list * Channels.chan_id list) Lwt.t
-  (* decode incomming message : the result is the list of channels to listen
+  (* decode incoming message : the result is the list of channels to listen
      to (on the left) or to signal non existence (on the right). *)
 
   val encode_downgoing :

--- a/src/extensions/ocsipersist-dbm/ocsipersist.ml
+++ b/src/extensions/ocsipersist-dbm/ocsipersist.ml
@@ -130,8 +130,8 @@ let rec get_indescr i =
        end
        else (Lwt_unix.sleep 2.1) >>= (fun () -> get_indescr (i-1))))
 
-let inch = ref (Lwt.fail (Failure "Ocsipersist not initalised"))
-let outch = ref (Lwt.fail (Failure "Ocsipersist not initalised"))
+let inch = ref (Lwt.fail (Failure "Ocsipersist not initialised"))
+let outch = ref (Lwt.fail (Failure "Ocsipersist not initialised"))
 
 let init_fun config =
   let (store, ocsidbmconf, delay_loading) =
@@ -354,7 +354,7 @@ let iter_block a b = failwith "iter_block not implemented for DBM. Please use Oc
 
 let length table =
   db_length table
-(* Because of Dbm implementation, the result may be less thann the expected
+(* Because of Dbm implementation, the result may be less than the expected
    result in some case (with a version of ocsipersist based on Dbm) *)
 
 let _ = Ocsigen_extensions.register_extension ~name:"ocsipersist" ~init_fun ()

--- a/src/extensions/staticmod.ml
+++ b/src/extensions/staticmod.ml
@@ -33,7 +33,7 @@ exception Not_concerned
 (*****************************************************************************)
 (* Structures describing the static pages a each virtual server *)
 
-(* A static site is either an entire directory served unconditionnaly,
+(* A static site is either an entire directory served unconditionally,
    or a more elaborate redirection based on regexpes and http error
    codes. See the web documentation of staticmod for detail *)
 type static_site_kind =

--- a/src/http/http_headers.mli
+++ b/src/http/http_headers.mli
@@ -112,7 +112,7 @@ val with_defaults : t -> t -> t
 
 
 val dyn_headers : t
-(** Headers for dynamic pages (non cachable) *)
+(** Headers for dynamic pages (non cacheable) *)
 
 type accept =
   ( (string option * string option)

--- a/src/http/multipart.ml
+++ b/src/http/multipart.ml
@@ -2,7 +2,7 @@
 (* Copyright Gerd Stolpmann, Patrick Doane *)
 (* Modified for Ocsigen/Lwt by Nataliya Guts and Vincent Balat *)
 
-(*VVV Check wether we should support int64 for large files? *)
+(*VVV Check whether we should support int64 for large files? *)
 
 open Ocsigen_lib
 

--- a/src/http/ocsigen_headers.ml
+++ b/src/http/ocsigen_headers.ml
@@ -18,7 +18,7 @@
 
 (* TODO: rewrite header parsing! *)
 
-(** This module is for getting informations from HTTP header. *)
+(** This module is for getting information from HTTP header. *)
 (** It uses the lowel level module Ocsigen_http_frame.Http_header.    *)
 (** It is very basic and must be completed for exhaustiveness. *)
 (* Operation on strings are hand-written ... *)

--- a/src/http/ocsigen_headers.mli
+++ b/src/http/ocsigen_headers.mli
@@ -16,7 +16,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 *)
 
-(** Getting informations from HTTP header. *)
+(** Getting information from HTTP header. *)
 (** This module uses the lowel level module Ocsigen_http_frame.Http_header.
      It is very basic and must be completed for exhaustiveness. *)
 

--- a/src/http/ocsigen_http_com.ml
+++ b/src/http/ocsigen_http_com.ml
@@ -43,7 +43,7 @@ open Ocsigen_cookies
 
 let section = Lwt_log.Section.make "ocsigen:http:com"
 
-(** this module provide a mecanism to communicate with some http frames *)
+(** this module provide a mechanism to communicate with some http frames *)
 
 let (>>=) = Lwt.(>>=)
 
@@ -602,7 +602,7 @@ let gmtdate d =
 type sender_type = {
   (** protocol to be used : HTTP/1.0 HTTP/1.1 *)
   mutable s_proto: Ocsigen_http_frame.Http_header.proto;
-  (** the options to send with each frame, for exemple : server name , ... *)
+  (** the options to send with each frame, for example : server name , ... *)
   mutable s_headers: Http_headers.t
 }
 

--- a/src/http/ocsigen_http_frame.ml
+++ b/src/http/ocsigen_http_frame.ml
@@ -20,10 +20,10 @@
 
 open Ocsigen_lib
 
-(** this set of modules discribes the http protocol and
+(** this set of modules describes the http protocol and
     the operation on this protocol*)
 
-(** this signature provides a template to discribe the content of a http
+(** this signature provides a template to describe the content of a http
     frame *)
 
 open Ocsigen_stream
@@ -87,7 +87,7 @@ module Result = struct
             int64 ->
               string Ocsigen_stream.step Lwt.t) option
        ; (** Default: empty stream.
-             The second field is (optionaly)
+             The second field is (optionally)
              the function used to skip a part of the
              stream, if you do not you want to use
              a basic reading of the stream.
@@ -269,7 +269,7 @@ struct
       the error, some comment, and some headers. *)
   exception Http_exception of int * string option * Http_headers.t option
 
-  (* this fonction provides the translation mecanisme between a code and
+  (* this function provides the translation mecanisme between a code and
    * its explanation *)
   let expl_of_code =
     function

--- a/src/http/ocsigen_senders.ml
+++ b/src/http/ocsigen_senders.ml
@@ -98,7 +98,7 @@ struct
      etag match and respond with code 412 ( precondition failed ).
      Since the etag is calculated from the content of the answer,
      we cannot enforce this semantic correctly, so it is better not
-     to send etags with POST requests. Here, we cannot know wether
+     to send etags with POST requests. Here, we cannot know whether
      the request was in POST or GET, so the easiest way to fix that
      is to never send etags *)
 
@@ -214,7 +214,7 @@ end
 (*****************************************************************************)
 (* Files *)
 
-(** this module instanciate the HTTP_CONTENT signature for files *)
+(** this module instantiate the HTTP_CONTENT signature for files *)
 module File_content =
 struct
   type t =
@@ -300,7 +300,7 @@ end
 (*****************************************************************************)
 (* directory listing - by Gabriel Kerneis *)
 
-(** this module instanciate the HTTP_CONTENT signature for directories *)
+(** this module instantiate the HTTP_CONTENT signature for directories *)
 module Directory_content =
 struct
   type t = string (* dir name *) * string list (* corresponding URL path *)

--- a/src/server/ocsigen_extensions.ml
+++ b/src/server/ocsigen_extensions.ml
@@ -219,7 +219,7 @@ type answer =
   (** Found but do not try next extensions *)
   | Ext_next of int (** Page not found. Try next extension.
                         The integer is the HTTP error code.
-                        It is usally 404, but may be for ex 403 (forbidden)
+                        It is usually 404, but may be for ex 403 (forbidden)
                         if you want another extension to try after a 403.
                         Same as Ext_continue_with but does not change
                         the request.
@@ -227,19 +227,19 @@ type answer =
   | Ext_stop_site of (Ocsigen_cookies.cookieset * int)
   (** Error. Do not try next extension, but
       try next site.
-      The integer is the HTTP error code, usally 403.
+      The integer is the HTTP error code, usually 403.
   *)
   | Ext_stop_host of (Ocsigen_cookies.cookieset * int)
   (** Error. Do not try next extension,
       do not try next site,
       but try next host.
-      The integer is the HTTP error code, usally 403.
+      The integer is the HTTP error code, usually 403.
   *)
   | Ext_stop_all of (Ocsigen_cookies.cookieset * int)
   (** Error. Do not try next extension,
       do not try next site,
       do not try next host.
-      The integer is the HTTP error code, usally 403.
+      The integer is the HTTP error code, usually 403.
   *)
   | Ext_continue_with of (request * Ocsigen_cookies.cookieset * int)
   (** Used to modify the request before giving it to next extension.

--- a/src/server/ocsigen_extensions.mli
+++ b/src/server/ocsigen_extensions.mli
@@ -59,7 +59,7 @@ val badconfig : ('a, unit, string, 'b) format4 -> 'a
 (** Type of the result of parsing the field [hostfiler] in the configuration
     file. Inside the list, the first argument is the host itself
     (which is a glob-like pattern that can contains [*]), a regexp
-    parsing this pattern, and optionnaly a port.
+    parsing this pattern, and optionally a port.
 *)
 type virtual_hosts = (string * Netstring_pcre.regexp * int option) list
 
@@ -179,7 +179,7 @@ type answer =
   (** Found but do not try next extensions *)
   | Ext_next of int (** Page not found. Try next extension.
                         The integer is the HTTP error code.
-                        It is usally 404, but may be for ex 403 (forbidden)
+                        It is usually 404, but may be for ex 403 (forbidden)
                         if you want another extension to try after a 403.
                         Same as Ext_continue_with but does not change
                         the request.
@@ -187,20 +187,20 @@ type answer =
   | Ext_stop_site of (Ocsigen_cookies.cookieset * int)
   (** Error. Do not try next extension, but
       try next site.
-      The integer is the HTTP error code, usally 403.
+      The integer is the HTTP error code, usually 403.
   *)
   | Ext_stop_host of (Ocsigen_cookies.cookieset * int)
   (** Error. Do not try next extension,
       do not try next site,
       but try next host.
-      The integer is the HTTP error code, usally 403.
+      The integer is the HTTP error code, usually 403.
   *)
   | Ext_stop_all of (Ocsigen_cookies.cookieset * int)
   (** Error. Do not try next extension (even filters),
       do not try next site,
       do not try next host,
       do not .
-      The integer is the HTTP error code, usally 403.
+      The integer is the HTTP error code, usually 403.
   *)
   | Ext_continue_with of (request * Ocsigen_cookies.cookieset * int)
   (** Used to modify the request before giving it to next extension.

--- a/src/server/ocsigen_http_client.ml
+++ b/src/server/ocsigen_http_client.ml
@@ -108,7 +108,7 @@ let connection_table = T.create 100
   in order to try to pipeline them on the same output connection.
 
   If the client parameter is not present, we do the
-  requests independantly.
+  requests independently.
   We try to find a free connection to the right server
   or we create one if there is none.
   In that case, the distant server may have the request in wrong order.

--- a/src/server/ocsigen_http_client.mli
+++ b/src/server/ocsigen_http_client.mli
@@ -128,7 +128,7 @@ val raw_request :
    If the optional argument [headers] is present, no headers will be
    added by Ocsigen, but those in this argument and host, and
    [connection: close] or [connection: keep-alive].
-   Be carefull to respect HTTP/1.1 in this case!
+   Be careful to respect HTTP/1.1 in this case!
    ([host] is the full Host HTTP field to send).
 
    The default port is 80 for HTTP, 443 for HTTPS.

--- a/src/server/ocsigen_parseconfig.mli
+++ b/src/server/ocsigen_parseconfig.mli
@@ -63,7 +63,7 @@ type ssl_info = {
   ssl_curve       : string option
 }
 
-(** First pass of parse XML file. Extracts this informations:
+(** First pass of parse XML file. Extracts this information:
     {ul
     {- user to execute OcsigenServer (ex: www-data) }
     {- group to execute OcsigenServer (ex: www-data) }

--- a/src/server/ocsigen_request_info.ml
+++ b/src/server/ocsigen_request_info.ml
@@ -34,7 +34,7 @@ type request_info =
    remote_ip: string;            (** IP of the client *)
    remote_ip_parsed: Ipaddr.t Lazy.t;    (** IP of the client, parsed *)
    remote_port: int;      (** Port used by the client *)
-   forward_ip: string list; (** IPs of gateways the request went throught *)
+   forward_ip: string list; (** IPs of gateways the request went through *)
    server_port: int;      (** Port of the request (server) *)
    user_agent: string;    (** User_agent of the browser *)
    cookies_string: string option Lazy.t; (** Cookies sent by the browser *)

--- a/src/server/ocsigen_socket.mli
+++ b/src/server/ocsigen_socket.mli
@@ -7,7 +7,7 @@ type socket_type =
   | IPv6 of Unix.inet_addr
 
 (** make_sockets create socket ready to listen in addr:port
-    @param addr type of addresss (All | IPv4 | IPv6)
+    @param addr type of addresses (All | IPv4 | IPv6)
     @param port port of socket
 *)
 val make_sockets : socket_type -> int -> Lwt_unix.file_descr list Lwt.t


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell