### PR TITLE
No longer invoke Dynlink.init

### DIFF
--- a/src/baselib/dynlink_wrapper.natdynlink.ml
+++ b/src/baselib/dynlink_wrapper.natdynlink.ml
@@ -26,8 +26,6 @@ let loadfile = loadfile
 
 let error_message = error_message
 
-let init = init
-
 let allow_unsafe_modules = allow_unsafe_modules
 
 let prohibit = prohibit

--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -1314,7 +1314,6 @@ let start_server () =
                 (fun s -> Lwt_log.ign_error ~section s));
 
       (* Now I can load the modules *)
-      Dynlink_wrapper.init ();
       Dynlink_wrapper.allow_unsafe_modules true;
 
       Ocsigen_extensions.start_initialisation ();


### PR DESCRIPTION
This function was deprecated and has been removed in OCaml 4.08