### PR TITLE
command-line parameters reflecting the verbosity levels of Lwt_log

### DIFF
--- a/src/baselib/ocsigen_commandline.ml
+++ b/src/baselib/ocsigen_commandline.ml
@@ -29,10 +29,12 @@ let cmdline : unit =
        ("--silent", Arg.Unit set_silent, "Silent mode (error messages in errors.log only)");
        ("-p", Arg.String set_pidfile, "Specify a file where to write the PIDs of servers");
        ("--pidfile", Arg.String set_pidfile, "Specify a file where to write the PIDs of servers");
-       ("-v", Arg.Unit set_verbose, "Verbose mode");
-       ("--verbose", Arg.Unit set_verbose, "Verbose mode");
-       ("-V", Arg.Unit set_veryverbose, "Very verbose mode (debug)");
-       ("--veryverbose", Arg.Unit set_veryverbose, "Very verbose mode (debug)");
+       ("-v", Arg.Unit set_verbose, "Verbose mode (notice)");
+       ("--verbose", Arg.Unit set_verbose, "Verbose mode (notice)");
+       ("-vv", Arg.Unit set_veryverbose, "Very verbose mode (info)");
+       ("--veryverbose", Arg.Unit set_veryverbose, "Very verbose mode (info)");
+       ("-vvv", Arg.Unit set_debug, "Extremely verbose mode (info)");
+       ("--debug", Arg.Unit set_debug, "Extremely verbose mode (debug)");
        ("-d", Arg.Unit set_daemon, "Daemon mode (detach the process)");
        ("--daemon", Arg.Unit set_daemon, "Daemon mode (detach the process) (This is the default when there are more than 1 process)");
        ("--version", Arg.Unit display_version, "Display version number and exit")

--- a/src/baselib/ocsigen_config.ml.in
+++ b/src/baselib/ocsigen_config.ml.in
@@ -80,6 +80,7 @@ let set_syslog_facility f = syslog_facility := f; logdir := None
 let set_configfile s = config_file := s
 let set_pidfile s = pidfile := Some s
 let set_mimefile s = mimefile := s
+let () = Lwt_log.add_rule "*" Lwt_log.Warning (* without --verbose *)
 let set_verbose () =
   verbose := true;
   Lwt_log.add_rule "*" Lwt_log.Notice

--- a/src/baselib/ocsigen_config.ml.in
+++ b/src/baselib/ocsigen_config.ml.in
@@ -28,6 +28,7 @@ let verbose = ref false
 let silent = ref false
 let daemon = ref false
 let veryverbose = ref false
+let debug = ref false
 let version_number = (**)"0000000000000000"(**)
 let pidfile = ref None
 let server_name = "Ocsigen"
@@ -81,12 +82,17 @@ let set_pidfile s = pidfile := Some s
 let set_mimefile s = mimefile := s
 let set_verbose () =
   verbose := true;
-  Lwt_log.add_rule "*" Lwt_log.Info
+  Lwt_log.add_rule "*" Lwt_log.Notice
 let set_silent () = silent := true
 let set_daemon () = set_silent (); daemon := true
 let set_veryverbose () =
   verbose := true;
   veryverbose := true;
+  Lwt_log.add_rule "*" Lwt_log.Info
+let set_debug () =
+  verbose := true;
+  veryverbose := true;
+  debug := true;
   Lwt_log.add_rule "*" Lwt_log.Debug
 
 let set_minthreads i = minthreads := i
@@ -133,6 +139,7 @@ let get_verbose () = !verbose
 let get_silent () = !silent
 let get_daemon () = !daemon
 let get_veryverbose () = !veryverbose
+let get_debug () = !debug
 let get_default_user () = !default_user
 let get_default_group () = !default_group
 let get_minthreads () = !minthreads

--- a/src/baselib/ocsigen_config.mli
+++ b/src/baselib/ocsigen_config.mli
@@ -39,6 +39,7 @@ val set_verbose : unit -> unit
 val set_silent : unit -> unit
 val set_daemon : unit -> unit
 val set_veryverbose : unit -> unit
+val set_debug : unit -> unit
 val set_minthreads : int -> unit
 val set_maxthreads : int -> unit
 val set_max_number_of_threads_queued : int -> unit
@@ -76,6 +77,7 @@ val get_verbose : unit -> bool
 val get_silent : unit -> bool
 val get_daemon : unit -> bool
 val get_veryverbose : unit -> bool
+val get_debug : unit -> bool
 val get_default_user : unit -> string
 val get_default_group : unit -> string
 val get_minthreads : unit -> int

--- a/src/files/ocsigenserver.1
+++ b/src/files/ocsigenserver.1
@@ -33,10 +33,13 @@ Specify a file where to write the PIDs of the servers.
 Silent mode (error messages go in errors.log only).
 .TP
 .BR \-v ,\  \-\-verbose
-Verbose mode.
+Verbose mode (notice).
 .TP
-.B \-V ,\  \-\-veryverbose
-Very verbose mode (debug).
+.B \-vv ,\  \-\-veryverbose
+Very verbose mode (info).
+.TP
+.B \-vvv ,\  \-\-debug
+Extremely verbose mode (debug).
 .TP
 .B \-\-version
 Show version of program.


### PR DESCRIPTION
Ocsigen_config: be a bit less verbose on -v
reverts 20f7f1c66d66a63d077febebc7fe8b169d2af275