### PR TITLE
fix logging issues

### DIFF
--- a/src/baselib/ocsigen_commandline.ml
+++ b/src/baselib/ocsigen_commandline.ml
@@ -25,8 +25,8 @@ let cmdline : unit =
         "Alternate config file (default "^ Ocsigen_config.get_config_file() ^")");
        ("--config", Arg.String set_configfile,
         "Alternate config file (default "^ Ocsigen_config.get_config_file() ^")");
-       ("-s", Arg.Unit set_silent, "Silent mode (error messages in errors.log only)");
-       ("--silent", Arg.Unit set_silent, "Silent mode (error messages in errors.log only)");
+       ("-s", Arg.Unit set_silent, "silent mode (no logging to console; does not affect *.log files)");
+       ("--silent", Arg.Unit set_silent, "silent mode (no logging to console; does not affect *.log files)");
        ("-p", Arg.String set_pidfile, "Specify a file where to write the PIDs of servers");
        ("--pidfile", Arg.String set_pidfile, "Specify a file where to write the PIDs of servers");
        ("-v", Arg.Unit set_verbose, "Verbose mode (notice)");

--- a/src/baselib/ocsigen_config.ml.in
+++ b/src/baselib/ocsigen_config.ml.in
@@ -80,7 +80,7 @@ let set_syslog_facility f = syslog_facility := f; logdir := None
 let set_configfile s = config_file := s
 let set_pidfile s = pidfile := Some s
 let set_mimefile s = mimefile := s
-let () = Lwt_log.add_rule "*" Lwt_log.Warning (* without --verbose *)
+let () = Lwt_log.add_rule "ocsigen:*" Lwt_log.Warning (* without --verbose *)
 let set_verbose () =
   verbose := true;
   Lwt_log.add_rule "ocsigen:*" Lwt_log.Notice


### PR DESCRIPTION
- all sections (including "access") are now prefixed by "ocsigen:"
- default logging level is only applied to "ocsigen:*" instead of "*"
- always log access.log (wasn't previously the case)
- only level warning/error/fatal points to stderr, otherwise to stdout