### PR TITLE
functorial interface for Ocsipersist

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigenserver"
-version: "2.16.1"
+version: "2.17.0"
 maintainer: "dev@ocsigen.org"
 synopsis: "A full-featured and extensible Web server"
 description: "Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."


### PR DESCRIPTION
New functorial interface allows for different column types in
Sqlite/PostgreSQL instead of storing everything as text/blobs/strings.
This way keys and values can be stored and retrieved without
necessarily marshalling/unmarshalling them. This allows for better
readability of the data in the DB for instance via the psql interactive
terminal, and for higher-performance organisation of the data.