### PR TITLE
Fix cohttp version of Ocsigen_request.update

### DIFF
--- a/src/server/ocsigen_request.ml
+++ b/src/server/ocsigen_request.ml
@@ -173,7 +173,9 @@ let update
     match post_data with
     | Some (Some post_data) ->
       ref (`Parsed (Lwt.return post_data))
-    | None | Some None ->
+    | Some None ->
+      ref (`Parsed (Lwt.return ([], [])))
+    | None ->
       r_body
   and r_cookies_override =
     match cookies_override with


### PR DESCRIPTION
@vouillon You changed this some time ago. Are you ok with this version?

It fixes actions. update ~post_params:None was not removing post params.