### PR TITLE
set Lwt.async_exception_hook earlier to catch early exceptions

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigenserver"
-version: "3.0.0"
+version: "3.0.1"
 maintainer: "dev@ocsigen.org"
 synopsis: "A full-featured and extensible Web server"
 description: "Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."


### PR DESCRIPTION
Currently the following piece of server-side code will make the server crash:
let () = Lwt.async @@ fun () -> failwith __LOC__