### PR TITLE
Make sure a simple local `make` compiles everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ default all: build
 .PHONY: build
 build:
 	${MAKE} -C src
+	dune build
 doc:
 	$(MAKE) -C doc
 


### PR DESCRIPTION
This is again a consequence of https://github.com/ocaml/dune/issues/4065