### PR TITLE
Fix: was not possible to run the server on port 80/443 when using <user> in config file

### DIFF
--- a/ocsigenserver.opam
+++ b/ocsigenserver.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocsigenserver"
-version: "5.0.1"
+version: "5.0.2"
 maintainer: "dev@ocsigen.org"
 synopsis: "A full-featured and extensible Web server"
 description: "Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."


### PR DESCRIPTION
 HACK! Add a 2s delay before changing user to wait for the cohttp server to be initialized

Cohttp does not return after listening
This fixes: was not possible to run the server on port 80/443 when using <user> in config file
(Regression during switch to cohttp)