### PR TITLE
Fix obsolete libraries

### DIFF
--- a/Makefile.options
+++ b/Makefile.options
@@ -23,7 +23,7 @@ INCS=   -I ${BLD}/server/.ocsigenserver.objs/byte \
 ## ${SERVER_PACKAGE} is not only used to build the 'ocsigenserver' executable
 ## but also to generate src/baselib/ocsigen_config_static.ml
 
-SERVER_PACKAGE := lwt_ssl,bytes,lwt.unix,lwt_log,ipaddr,findlib,cryptokit,pcre,str,xml-light,dynlink,cohttp-lwt-unix,hmap
+SERVER_PACKAGE := lwt_ssl,bytes,lwt.unix,lwt_log,ipaddr,findlib,cryptokit,re,str,xml-light,dynlink,cohttp-lwt-unix,hmap
 
 LIBS := -package ${SERVER_PACKAGE} ${INCS}
 

--- a/configure
+++ b/configure
@@ -401,7 +401,7 @@ check_library lwt_react   "See: http://ocsigen.org/lwt"
 check_library lwt_ssl   "See: http://ocsigen.org/lwt"
 check_library lwt_log   "See: http://ocsigen.org/lwt"
 
-check_library pcre "See: http://ocaml.info/home/ocaml_sources.html"
+check_library re "See: https://github.com/ocaml/ocaml-re/"
 check_library cryptokit "See: http://pauillac.inria.fr/~xleroy/software.html#cryptokit"
 
 check_library xml-light "See: https://github.com/ncannasse/xml-light"

--- a/ocsigenserver.opam
+++ b/ocsigenserver.opam
@@ -57,7 +57,7 @@ depends: [
   "pcre"
   "cryptokit"
   "ipaddr" {>= "2.1"}
-  "cohttp-lwt-unix" {< "5.0.0"}
+  "cohttp-lwt-unix" {>= "5.0.0"}
   "conduit-lwt-unix" {>= "2.0.0"}
   "hmap"
   "xml-light"

--- a/ocsigenserver.opam
+++ b/ocsigenserver.opam
@@ -54,7 +54,7 @@ depends: [
   "lwt_ssl"
   "lwt_react"
   "lwt_log"
-  "pcre"
+  "re" {>= "1.11.0"}
   "cryptokit"
   "ipaddr" {>= "2.1"}
   "cohttp-lwt-unix" {>= "5.0.0"}

--- a/src/baselib/dune
+++ b/src/baselib/dune
@@ -18,7 +18,7 @@
     ocsigen_loader
     ocsigen_stream)
   (libraries
-     str findlib lwt_log lwt.unix cryptokit pcre ocsigen_lib_base
+     str findlib lwt_log lwt.unix cryptokit re ocsigen_lib_base
      (select dynlink_wrapper.ml from
        (dynlink -> dynlink_wrapper.natdynlink.ml)
        (_ -> dynlink_wrapper.nonatdynlink.ml))))

--- a/src/baselib/ocsigen_lib.mli
+++ b/src/baselib/ocsigen_lib.mli
@@ -95,13 +95,15 @@ end
 (* This exists to facilitate transition away from Ocamlnet. Do not use
    for new code! *)
 module Netstring_pcre : sig
+  open Re
+
   val regexp : string -> Pcre.regexp
-  val matched_group : Pcre.substrings -> int -> string -> string
-  val matched_string : Pcre.substrings -> string -> string
+  val matched_group : Pcre.groups -> int -> string -> string
+  val matched_string : Pcre.groups -> string -> string
   val global_replace : Pcre.regexp -> string -> string -> string
-  val search_forward : Pcre.regexp -> string -> int -> int * Pcre.substrings
+  val search_forward : Pcre.regexp -> string -> int -> int * Pcre.groups
   val split : Pcre.regexp -> string -> string list
-  val string_match : Pcre.regexp -> string -> int -> Pcre.substrings option
+  val string_match : Pcre.regexp -> string -> int -> Pcre.groups option
 end
 
 module Date : sig

--- a/src/baselib/ocsigen_loader.ml
+++ b/src/baselib/ocsigen_loader.ml
@@ -147,7 +147,7 @@ let add_ocamlpath p =
 (* Using Findlib to locate files *)
 
 let findfiles =
-  let cmx = Pcre.regexp ~flags:[`MULTILINE; `CASELESS] "\\.cmx($| |a)" in
+  let cmx = Re.Pcre.regexp ~flags:[`MULTILINE; `CASELESS] "\\.cmx($| |a)" in
   fun package ->
     try
       let preds =

--- a/src/baselib/ocsigen_stream.ml
+++ b/src/baselib/ocsigen_stream.ml
@@ -180,7 +180,7 @@ let substream delim s =
   if ldelim = 0
   then Lwt.fail (Stream_error "Empty delimiter")
   else
-    let rdelim = Pcre.(regexp (quote delim)) in
+    let rdelim = Re.Pcre.(regexp (quote delim)) in
     let rec aux = function
       | Finished _ -> Lwt.fail Stream_too_small
       | Cont (s, f) as stre -> (

--- a/src/extensions/outputfilter.ml
+++ b/src/extensions/outputfilter.ml
@@ -21,7 +21,7 @@
 (* This module enables rewritting the server output *)
 
 type header_filter =
-  [ `Rewrite of Ocsigen_header.Name.t * Pcre.regexp * string
+  [ `Rewrite of Ocsigen_header.Name.t * Re.Pcre.regexp * string
   | `Add of Ocsigen_header.Name.t * string * bool option ]
 
 let gen filter = function

--- a/src/extensions/outputfilter.mli
+++ b/src/extensions/outputfilter.mli
@@ -1,5 +1,5 @@
 val mode
-  : [ `Rewrite of Ocsigen_header.Name.t * Pcre.regexp * string
+  : [ `Rewrite of Ocsigen_header.Name.t * Re.Pcre.regexp * string
     | `Add of Ocsigen_header.Name.t * string * bool option
     | `Code of Cohttp.Code.status ]
     Ocsigen_server.Site.Config.key

--- a/src/extensions/redirectmod.ml
+++ b/src/extensions/redirectmod.ml
@@ -20,6 +20,8 @@
 
 (* Define page redirections in the configuration file *)
 
+module Pcre = Re.Pcre
+
 let section = Lwt_log.Section.make "ocsigen:ext:redirectmod"
 
 (* The table of redirections for each virtual server *)

--- a/src/extensions/revproxy.ml
+++ b/src/extensions/revproxy.ml
@@ -23,6 +23,7 @@
     The reverse proxy is still experimental. *)
 
 open Lwt.Infix
+module Pcre = Re.Pcre
 
 let section = Lwt_log.Section.make "ocsigen:ext:revproxy"
 

--- a/src/extensions/rewritemod.ml
+++ b/src/extensions/rewritemod.ml
@@ -20,6 +20,8 @@
 
 (* Rewrite URLs in the configuration file *)
 
+module Pcre = Re.Pcre
+
 (* IMPORTANT WARNING
 
    It is really basic for now:

--- a/src/extensions/staticmod.ml
+++ b/src/extensions/staticmod.ml
@@ -19,6 +19,7 @@
  *)
 
 open Lwt.Infix
+module Pcre = Re.Pcre
 
 let name = "staticmod"
 let section = Lwt_log.Section.make "ocsigen:ext:staticmod"
@@ -233,7 +234,7 @@ let parse_config userconf _ : Ocsigen_extensions.parse_config_aux =
               ; Configuration.attribute ~name:"regexp" (fun s ->
                     let s =
                       try Ocsigen_lib.Netstring_pcre.regexp ("^" ^ s ^ "$")
-                      with Pcre.Error (Pcre.BadPattern _) ->
+                      with Re.Pcre.Parse_error | Re.Pcre.Not_supported ->
                         badconfig
                           "Bad regexp \"%s\" in <static regexp=\"...\" />" s
                     in
@@ -241,7 +242,7 @@ let parse_config userconf _ : Ocsigen_extensions.parse_config_aux =
               ; Configuration.attribute ~name:"code" (fun s ->
                     let c =
                       try Ocsigen_lib.Netstring_pcre.regexp ("^" ^ s ^ "$")
-                      with Pcre.Error (Pcre.BadPattern _) ->
+                      with Re.Pcre.Parse_error | Re.Pcre.Not_supported ->
                         badconfig "Bad regexp \"%s\" in <static code=\"...\" />"
                           s
                     in

--- a/src/http/ocsigen_charset_mime.ml
+++ b/src/http/ocsigen_charset_mime.ml
@@ -31,7 +31,7 @@ let section = Lwt_log.Section.make "ocsigen:mimetype"
 type 'a assoc_item =
   | Extension of extension * 'a
   | File of filename * 'a
-  | Regexp of Pcre.regexp * 'a
+  | Regexp of Re.Pcre.regexp * 'a
   | Map of 'a MapString.t
 
 type 'a assoc = {assoc_list : 'a assoc_item list; assoc_default : 'a}

--- a/src/http/ocsigen_charset_mime.mli
+++ b/src/http/ocsigen_charset_mime.mli
@@ -55,7 +55,7 @@ val update_charset_file : charset_assoc -> filename -> charset -> charset_assoc
 
 val update_charset_regexp
   :  charset_assoc
-  -> Pcre.regexp
+  -> Re.Pcre.regexp
   -> charset
   -> charset_assoc
 
@@ -81,4 +81,4 @@ val default_mime : mime_assoc -> mime_type
 val set_default_mime : mime_assoc -> mime_type -> mime_assoc
 val update_mime_ext : mime_assoc -> extension -> mime_type -> mime_assoc
 val update_mime_file : mime_assoc -> filename -> mime_type -> mime_assoc
-val update_mime_regexp : mime_assoc -> Pcre.regexp -> mime_type -> mime_assoc
+val update_mime_regexp : mime_assoc -> Re.Pcre.regexp -> mime_type -> mime_assoc

--- a/src/server/ocsigen_cohttp.ml
+++ b/src/server/ocsigen_cohttp.ml
@@ -12,23 +12,12 @@ exception
     @param request Cohttp request *)
 
 let _print_request fmt request =
-  let print_list print_data out_ch lst =
-    let rec aux = function
-      | [] -> ()
-      | [x] -> print_data out_ch x
-      | x :: r -> print_data out_ch x; aux r
-    in
-    aux lst
-  in
   Format.fprintf fmt "%s [%s/%s]:\n"
     (Uri.to_string (Cohttp.Request.uri request))
     Cohttp.(Code.string_of_version (Request.version request))
     Cohttp.(Code.string_of_method (Request.meth request));
   Cohttp.Header.iter
-    (fun key values ->
-      print_list
-        (fun fmt value -> Format.fprintf fmt "\t%s = %s\n" key value)
-        fmt values)
+    (fun key value -> Format.fprintf fmt "\t%s = %s\n" key value)
     (Cohttp.Request.headers request)
 
 let connections = Hashtbl.create 256

--- a/src/server/ocsigen_extensions.ml
+++ b/src/server/ocsigen_extensions.ml
@@ -21,6 +21,7 @@
 let section = Lwt_log.Section.make "ocsigen:ext"
 
 open Lwt.Infix
+module Pcre = Re.Pcre
 module Url = Ocsigen_lib.Url
 include Ocsigen_command
 

--- a/src/server/ocsigen_extensions.mli
+++ b/src/server/ocsigen_extensions.mli
@@ -48,7 +48,7 @@ val badconfig : ('a, unit, string, 'b) format4 -> 'a
 
 (*****************************************************************************)
 
-type virtual_hosts = (string * Pcre.regexp * int option) list
+type virtual_hosts = (string * Re.Pcre.regexp * int option) list
 (** Type of the result of parsing the field [hostfiler] in the configuration
     file. Inside the list, the first argument is the host itself
     (which is a glob-like pattern that can contains [*]), a regexp
@@ -76,7 +76,7 @@ val serve_everything : do_not_serve
 
 exception IncorrectRegexpes of do_not_serve
 
-val do_not_serve_to_regexp : do_not_serve -> Pcre.regexp
+val do_not_serve_to_regexp : do_not_serve -> Re.Pcre.regexp
 (** Compile a do_not_serve structure into a regexp. Raises
     [IncorrectRegexpes] if the compilation fails. The result is
     memoized for subsequent calls with the same argument *)
@@ -380,14 +380,14 @@ type ud_string
 
 val parse_user_dir : string -> ud_string
 
-val replace_user_dir : Pcre.regexp -> ud_string -> string -> string
+val replace_user_dir : Re.Pcre.regexp -> ud_string -> string -> string
 (** raises [Not_found] is the directory does not exist *)
 
 exception Not_concerned
 (** {3 Regular expressions for redirections} *)
 
 val find_redirection
-  :  Pcre.regexp
+  :  Re.Pcre.regexp
   -> bool
   -> string
   -> Ocsigen_request.t

--- a/src/server/ocsigen_multipart.ml
+++ b/src/server/ocsigen_multipart.ml
@@ -6,6 +6,7 @@
 
 open Lwt.Infix
 module S = Ocsigen_lib.Netstring_pcre
+module Pcre = Re.Pcre
 
 let section = Lwt_log.Section.make "ocsigen:server:multipart"
 

--- a/src/server/ocsigen_parseconfig.ml
+++ b/src/server/ocsigen_parseconfig.ml
@@ -207,7 +207,7 @@ let parse_host_field =
               in
               let split_host = function
                 | Str.Delim _ -> ".*"
-                | Str.Text t -> Pcre.quote t
+                | Str.Text t -> Re.Pcre.quote t
               in
               ( host
               , Netstring_pcre.regexp


### PR DESCRIPTION
This pull request removes the need for obsolete libraries:
- cohttp 4.x: the fix is simple and already reported in #228 
- pcre: I chose to fix this one by using re instead (see https://github.com/mmottl/pcre-ocaml/issues/25)