### PR TITLE
Add support for directory listings in `Staticmod`

### DIFF
--- a/src/extensions/dune
+++ b/src/extensions/dune
@@ -56,7 +56,7 @@
   (name staticmod)
   (public_name ocsigenserver.ext.staticmod)
   (modules staticmod)
-  (libraries ocsigenserver))
+  (libraries tyxml ocsigenserver))
 
 (library
   (name userconf)


### PR DESCRIPTION
The goal of this PR is to implement the `"FIXME: staticmod dirs not implemented"`. The implementation might be too naïve to be included, at least as is. In particular:

- the generation must load the full directory (so that the entries can be sorted),
- consequently the generation should probably not be enabled when there are huge directories (which are usually a bad idea anyhow),
- the listings are unstyled.

The idea was to make it so that
```ocaml
let () =
  let dir = Sys.getcwd () in
  Ocsigen_server.start
    ~ports:[ (`All, 8080) ]
    ~command_pipe:"/tmp/ocsigenserver-cmd" ~datadir:"/tmp" ~logdir:"/tmp" ~debugmode:true
    [
      Ocsigen_server.host
        [ Extendconfiguration.listdirs true; Staticmod.run ~dir () ];
    ]
```
is a possible `ocsigenserver` version of `python3 -m http.server`.