### PR TITLE
Remove unused Lwt utils

### DIFF
--- a/src/baselib/ocsigen_cache.mli
+++ b/src/baselib/ocsigen_cache.mli
@@ -125,12 +125,6 @@ module Dlist : sig
   (** fold over the elements from the cache starting from the oldest
       to the newest *)
 
-  val lwt_fold : ('b -> 'a -> 'b Lwt.t) -> 'b -> 'a t -> 'b Lwt.t
-  (** lwt version of fold *)
-
-  val lwt_fold_back : ('b -> 'a -> 'b Lwt.t) -> 'b -> 'a t -> 'b Lwt.t
-  (** lwt version of fold_back *)
-
   val move : 'a node -> 'a t -> 'a option
   (** Move a node from one dlist to another one, without finalizing.
       If one value is removed from the destination list (because its

--- a/src/baselib/ocsigen_lib_base.ml
+++ b/src/baselib/ocsigen_lib_base.ml
@@ -23,8 +23,8 @@ exception Ocsigen_Request_too_long
 
 external id : 'a -> 'a = "%identity"
 
-let ( >>= ) = Lwt.bind
-let ( >|= ) = Lwt.( >|= )
+include Lwt.Infix
+
 let ( !! ) = Lazy.force
 let ( |> ) x f = f x
 let ( @@ ) f x = f x
@@ -62,17 +62,6 @@ module Option = struct
   let return x = Some x
   let bind opt k = match opt with Some x -> k x | None -> None
   let to_list = function None -> [] | Some v -> [v]
-
-  module Lwt = struct
-    let map f = function
-      | Some x -> f x >>= fun v -> Lwt.return (Some v)
-      | None -> Lwt.return None
-
-    let get f = function Some x -> Lwt.return x | None -> f ()
-    let get' a = function Some x -> Lwt.return x | None -> a
-    let iter f = function Some x -> f x | None -> Lwt.return ()
-    let bind opt k = match opt with Some x -> k x | None -> Lwt.return None
-  end
 end
 
 module List = struct

--- a/src/baselib/ocsigen_lib_base.mli
+++ b/src/baselib/ocsigen_lib_base.mli
@@ -26,8 +26,8 @@ exception Input_is_too_large
 exception Ocsigen_Bad_Request
 exception Ocsigen_Request_too_long
 
-val ( >>= ) : 'a Lwt.t -> ('a -> 'b Lwt.t) -> 'b Lwt.t
-val ( >|= ) : 'a Lwt.t -> ('a -> 'b) -> 'b Lwt.t
+include module type of Lwt.Infix
+
 val ( !! ) : 'a Lazy.t -> 'a
 val ( |> ) : 'a -> ('a -> 'b) -> 'b
 val ( @@ ) : ('a -> 'b) -> 'a -> 'b
@@ -63,14 +63,6 @@ module Option : sig
   val return : 'a -> 'a t
   val bind : 'a t -> ('a -> 'b t) -> 'b t
   val to_list : 'a t -> 'a list
-
-  module Lwt : sig
-    val map : ('a -> 'b Lwt.t) -> 'a t -> 'b t Lwt.t
-    val get : (unit -> 'a Lwt.t) -> 'a t -> 'a Lwt.t
-    val get' : 'a Lwt.t -> 'a t -> 'a Lwt.t
-    val iter : ('a -> unit Lwt.t) -> 'a t -> unit Lwt.t
-    val bind : 'a t -> ('a -> 'b t Lwt.t) -> 'b t Lwt.t
-  end
 end
 
 (** Improvement of module List *)

--- a/src/server/ocsigen_messages.ml
+++ b/src/server/ocsigen_messages.ml
@@ -18,7 +18,8 @@
 
 (** Writing messages in the logs *)
 
-let ( >>= ) = Lwt.bind
+open Lwt.Infix
+
 let access_file = "access.log"
 let warning_file = "warnings.log"
 let error_file = "errors.log"


### PR DESCRIPTION
The redefined '>>=' operators are changed into opens of 'Lwt.Infix', which helps analyzing all Lwt call sites.

Other Lwt utils functions are removed when they are not used.