### PR TITLE
Fix Unix already loaded error

### DIFF
--- a/src/baselib/ocsigen_loader.ml
+++ b/src/baselib/ocsigen_loader.ml
@@ -84,7 +84,11 @@ let loadfile pre post force file =
        with e -> post (); raise e);
       addloaded file)
     else Lwt_log.ign_info_f ~section "Extension %s already loaded" file
-  with e -> raise (Dynlink_error (file, e))
+  with
+  | Dynlink.Error (Dynlink.Module_already_loaded m) ->
+      Lwt_log.ign_info_f ~section
+        "While loading extension %s: Module %s cannot be loaded again" file m
+  | e -> raise (Dynlink_error (file, e))
 
 let id () = ()
 


### PR DESCRIPTION
While migrating from Lwt_log to Logs, I got the basic eliom template fails with this message:
```
ocsigenserver: [ERROR] Fatal - While loading /nix/store/24p21ifnh3r3kb7fd69lc7pc2zmr9avz-ocaml-5.2.1/lib/ocaml/unix/unix.cma: The module `Unix' is already loaded (either by the main program or a previously-dynlinked library)
```
It seems that ocsigenserver now links Unix in a different order or perhaps Unix became a transitive dependency to something else?
Anyway, I think this error can be ignored.