### PR TITLE
Rename the 'http' library to 'ocsigen_http'

### DIFF
--- a/src/http/dune
+++ b/src/http/dune
@@ -5,7 +5,7 @@
  (libraries ocsigen_lib_base))
 
 (library
- (name http)
+ (name ocsigen_http)
  (public_name ocsigenserver.http)
  (wrapped false)
  (modules ocsigen_charset_mime ocsigen_header)

--- a/src/server/dune
+++ b/src/server/dune
@@ -8,4 +8,4 @@
   polytables
   ocsigen_cookie_map
   baselib
-  http))
+  ocsigen_http))


### PR DESCRIPTION
The 'http' library conflicts with the 'http' library distributed by cohttp: https://ocaml.org/p/http/latest

This is an internal change only, as the library is unwrapped and no module is renamed.