### PR TITLE
Add type annotation to ignored values

### DIFF
--- a/src/baselib/ocsigen_cache.ml
+++ b/src/baselib/ocsigen_cache.ml
@@ -291,7 +291,7 @@ end = struct
       | Some n when node == n -> ()
       | _ ->
           remove' node l;
-          ignore (add_node node l))
+          ignore (add_node node l : _ node option))
 
   (* assertion: = None *)
   (* we must not change the physical address => use add_node *)
@@ -440,7 +440,7 @@ functor
 
     let remove cache k =
       try
-        let _v, node = H.find cache.table k in
+        let (_v : A.value), node = H.find cache.table k in
         assert (
           match Dlist.list_of node with
           | None -> false
@@ -451,7 +451,7 @@ functor
     (* Add in a cache, under the hypothesis that the value is
        not already in the cache *)
     let add_no_remove cache k v =
-      ignore (Dlist.add k cache.pointers);
+      ignore (Dlist.add k cache.pointers : A.key option);
       match Dlist.newest cache.pointers with
       | None -> assert false
       | Some n -> H.add cache.table k (v, n)
@@ -465,7 +465,7 @@ functor
         cache.finder k >>= fun r ->
         (try
            (* it may have been added during cache.finder *)
-           ignore (find_in_cache cache k)
+           ignore (find_in_cache cache k : A.value)
          with Not_found -> add_no_remove cache k r);
         Lwt.return r
 

--- a/src/baselib/ocsigen_lib.ml
+++ b/src/baselib/ocsigen_lib.ml
@@ -130,11 +130,11 @@ module Netstring_pcre = struct
 
   let matched_group result n _ =
     if n < 0 || n >= Re.Group.nb_groups result then raise Not_found;
-    ignore (Pcre.get_substring_ofs result n);
+    ignore (Pcre.get_substring_ofs result n : int * int);
     Pcre.get_substring result n
 
   let matched_string result _ =
-    ignore (Pcre.get_substring_ofs result 0);
+    ignore (Pcre.get_substring_ofs result 0 : int * int);
     Pcre.get_substring result 0
 
   let global_replace pat templ s = Re.replace pat ~f:(tr_templ templ) s
@@ -427,7 +427,9 @@ module Url = struct
       https, host, port, uri_string, path, query, get_params
 
   let prefix_and_path_of_t url =
-    let https, host, port, _, path, _, _ = parse url in
+    let https, host, port, (_ : uri), path, (_ : uri option), (_ : _ Lazy.t) =
+      parse url
+    in
     let https_str =
       match https with
       | None -> ""

--- a/src/baselib/ocsigen_stream.ml
+++ b/src/baselib/ocsigen_stream.ml
@@ -189,7 +189,9 @@ let substream delim s =
           then enlarge_stream stre >>= aux
           else
             try
-              let p, _ = Ocsigen_lib.Netstring_pcre.search_forward rdelim s 0 in
+              let p, (_ : Re.Group.t) =
+                Ocsigen_lib.Netstring_pcre.search_forward rdelim s 0
+              in
               cont (String.sub s 0 p) (fun () ->
                 empty
                   (Some

--- a/src/baselib/ocsigen_stream.ml
+++ b/src/baselib/ocsigen_stream.ml
@@ -189,7 +189,7 @@ let substream delim s =
           then enlarge_stream stre >>= aux
           else
             try
-              let p, (_ : Re.Group.t) =
+              let p, (_ : 'groups) =
                 Ocsigen_lib.Netstring_pcre.search_forward rdelim s 0
               in
               cont (String.sub s 0 p) (fun () ->

--- a/src/baselib/tests/test_wrapping.ml
+++ b/src/baselib/tests/test_wrapping.ml
@@ -1,5 +1,5 @@
 (* ocamlfind ocamlopt -linkpkg -package react -g -I ../ ../wrapping.cmxa test_wrapping.ml -o test_wrapping *)
-let _ = Printexc.record_backtrace true
+let () = Printexc.record_backtrace true
 
 (*** simple wrap test ***)
 

--- a/src/extensions/accesscontrol.ml
+++ b/src/extensions/accesscontrol.ml
@@ -280,7 +280,7 @@ let parse_config parse_fun = function
         | Element ("then", [], ithen) :: q -> parse_fun ithen, q
         | _ -> Ocsigen_extensions.badconfig "Bad <then> branch in <if>"
       in
-      let ielse, _sub =
+      let ielse, (_sub : _ list) =
         match sub with
         | Element ("else", [], ielse) :: ([] as q) -> parse_fun ielse, q
         | [] -> parse_fun [], []

--- a/src/extensions/authbasic.ml
+++ b/src/extensions/authbasic.ml
@@ -42,7 +42,7 @@ let register_basic_authentication_method, get_basic_authentication_method =
     fun config -> !fun_auth config )
 
 (* Basic authentication with a predefined login/password (example) *)
-let _ =
+let () =
   let open Xml in
   register_basic_authentication_method @@ function
   | Element ("plain", [("login", login); ("password", password)], _) ->

--- a/src/extensions/deflatemod.ml
+++ b/src/extensions/deflatemod.ml
@@ -86,7 +86,7 @@ let rec output oz f buf pos len =
   else if len = 0
   then next_cont oz f
   else
-    let _, used_in, used_out =
+    let (_ : bool), used_in, used_out =
       try
         Zlib.deflate oz.stream
           (Bytes.unsafe_of_string buf)
@@ -133,7 +133,7 @@ and next_cont oz stream =
         else
           (* no more input, deflates only what were left because output buffer
            * was full *)
-          let finished, _, used_out =
+          let finished, (_ : int), used_out =
             Zlib.deflate oz.stream oz.buf 0 0 oz.buf oz.pos oz.avail
               Zlib.Z_FINISH
           in

--- a/src/extensions/extendconfiguration.ml
+++ b/src/extensions/extendconfiguration.ml
@@ -59,7 +59,7 @@ let check_regexp_list =
   try Hashtbl.find hashtbl r
   with Not_found -> (
     try
-      ignore (Ocsigen_lib.Netstring_pcre.regexp r);
+      ignore (Ocsigen_lib.Netstring_pcre.regexp r : Re.re);
       Hashtbl.add hashtbl r ()
     with _ -> raise (Bad_regexp r))
 

--- a/src/extensions/staticmod.ml
+++ b/src/extensions/staticmod.ml
@@ -61,7 +61,7 @@ let correct_user_local_file =
     try
       ignore
         (Ocsigen_lib.Netstring_pcre.search_forward regexp path 0
-         : int * Pcre.substrings);
+         : int * 'groups);
       false
     with Not_found -> true
 

--- a/src/extensions/staticmod.ml
+++ b/src/extensions/staticmod.ml
@@ -59,7 +59,9 @@ let correct_user_local_file =
   let regexp = Ocsigen_lib.Netstring_pcre.regexp "(/\\.\\./)|(/\\.\\.$)" in
   fun path ->
     try
-      ignore (Ocsigen_lib.Netstring_pcre.search_forward regexp path 0);
+      ignore
+        (Ocsigen_lib.Netstring_pcre.search_forward regexp path 0
+         : int * Pcre.substrings);
       false
     with Not_found -> true
 

--- a/src/server/ocsigen_cohttp.ml
+++ b/src/server/ocsigen_cohttp.ml
@@ -204,7 +204,7 @@ let shutdown timeout =
     | Some f -> fun () -> Lwt_unix.sleep f
     | None -> fun () -> Lwt.return ()
   in
-  ignore (Lwt.pick [process (); stop] >>= fun () -> exit 0)
+  ignore (Lwt.pick [process (); stop] >>= fun () -> exit 0 : unit Lwt.t)
 
 let service ?ssl ~address ~port ~connector () =
   let tls_own_key =

--- a/src/server/ocsigen_extensions.ml
+++ b/src/server/ocsigen_extensions.ml
@@ -636,12 +636,12 @@ module Configuration = struct
     raise (Error_in_user_config_file ("No PCDATA allowed in tag " ^ in_tag))
 
   let check_attribute_occurrence ~in_tag attributes = function
-    | name, {attribute_obligatory = true; _} -> (
-      try ignore (List.assoc name attributes)
-      with Not_found ->
-        raise
-          (Error_in_user_config_file
-             ("Obligatory attribute " ^ name ^ " not in tag " ^ in_tag)))
+    | name, {attribute_obligatory = true; _} ->
+        if not (List.mem_assoc name attributes)
+        then
+          raise
+            (Error_in_user_config_file
+               ("Obligatory attribute " ^ name ^ " not in tag " ^ in_tag))
     | _ -> ()
 
   let check_element_occurrence ~in_tag elements = function

--- a/src/server/ocsigen_local_files.ml
+++ b/src/server/ocsigen_local_files.ml
@@ -100,7 +100,9 @@ let check_dotdot =
        In URLs, .. have already been removed by the server,
        but the filename may come from somewhere else than URLs ... *)
     try
-      ignore (Ocsigen_lib.Netstring_pcre.search_forward regexp filename 0);
+      ignore
+        (Ocsigen_lib.Netstring_pcre.search_forward regexp filename 0
+         : int * Re.Group.t);
       false
     with Not_found -> true
 

--- a/src/server/ocsigen_local_files.ml
+++ b/src/server/ocsigen_local_files.ml
@@ -102,7 +102,7 @@ let check_dotdot =
     try
       ignore
         (Ocsigen_lib.Netstring_pcre.search_forward regexp filename 0
-         : int * Re.Group.t);
+         : int * 'groups);
       false
     with Not_found -> true
 

--- a/src/server/ocsigen_multipart.ml
+++ b/src/server/ocsigen_multipart.ml
@@ -86,7 +86,9 @@ let read_header ?downcase ?unfold ?strip s =
   in
   find_end_of_header s >>= fun (s, end_pos) ->
   let b = Ocsigen_stream.current_buffer s in
-  let h, _ = scan_header ?downcase ?unfold ?strip b ~start_pos:0 ~end_pos in
+  let h, (_ : int) =
+    scan_header ?downcase ?unfold ?strip b ~start_pos:0 ~end_pos
+  in
   Ocsigen_stream.skip s (Int64.of_int end_pos) >>= fun s -> Lwt.return (s, h)
 
 let lf_re = S.regexp "[\n]"
@@ -239,7 +241,7 @@ let counter =
     !c
 
 let field field content_disp =
-  let _, res =
+  let (_ : int), res =
     S.search_forward (S.regexp (field ^ "=.([^\"]*).;?")) content_disp 0
   in
   S.matched_group res 1 content_disp


### PR DESCRIPTION
This helps find ignored Lwt threads, which are a challenge to translate into direct-style concurrency. Ignoring a Lwt thread makes it implicitly fork in the background, which requires an explicit call with other concurrency libraries.
This makes finding these implicit forks a lot easier at the expense of added type annotations. 

Occurrences of ignored values were found using [this tool](https://github.com/Julow/lwt-to-direct-style/pull/9). Running this again in the future is not needed and type annotation can be removed later if needed.

Thanks @raphael-proust for suggesting the idea.