### PR TITLE
Remove usage of 'Lwt_preemptive'

### DIFF
--- a/src/server/ocsigen_config.ml
+++ b/src/server/ocsigen_config.ml
@@ -108,10 +108,6 @@ let set_debug () =
 
 let set_minthreads i = minthreads := i
 let set_maxthreads i = maxthreads := i
-
-let set_max_number_of_threads_queued =
-  Lwt_preemptive.set_max_number_of_threads_queued
-
 let set_max_number_of_connections i = max_number_of_connections := i
 let set_client_timeout i = silent_client_timeout := i
 let set_server_timeout i = silent_server_timeout := i
@@ -154,10 +150,6 @@ let get_veryverbose () = !veryverbose
 let get_debug () = !debug
 let get_minthreads () = !minthreads
 let get_maxthreads () = !maxthreads
-
-let get_max_number_of_threads_queued =
-  Lwt_preemptive.get_max_number_of_threads_queued
-
 let get_max_number_of_connections () = !max_number_of_connections
 let get_client_timeout () = !silent_client_timeout
 let get_server_timeout () = !silent_server_timeout

--- a/src/server/ocsigen_config.mli
+++ b/src/server/ocsigen_config.mli
@@ -56,7 +56,6 @@ val set_veryverbose : unit -> unit
 val set_debug : unit -> unit
 val set_minthreads : int -> unit
 val set_maxthreads : int -> unit
-val set_max_number_of_threads_queued : int -> unit
 val set_max_number_of_connections : int -> unit
 val set_client_timeout : int -> unit
 val set_server_timeout : int -> unit
@@ -92,7 +91,6 @@ val get_veryverbose : unit -> bool
 val get_debug : unit -> bool
 val get_minthreads : unit -> int
 val get_maxthreads : unit -> int
-val get_max_number_of_threads_queued : unit -> int
 val get_max_number_of_connections : unit -> int
 val get_client_timeout : unit -> int
 val get_server_timeout : unit -> int

--- a/src/server/ocsigen_parseconfig.ml
+++ b/src/server/ocsigen_parseconfig.ml
@@ -445,10 +445,6 @@ and later_pass = function
       later_pass ll
   | Element ("minthreads", [], _p) :: ll -> later_pass ll
   | Element ("maxthreads", [], _p) :: ll -> later_pass ll
-  | Element (("maxdetachedcomputationsqueued" as st), [], p) :: ll ->
-      set_max_number_of_threads_queued
-        (int_of_string st (parse_string_tag st p));
-      later_pass ll
   | Element (("maxconnected" as st), [], p) :: ll ->
       set_max_number_of_connections (int_of_string st (parse_string_tag st p));
       later_pass ll

--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -278,8 +278,6 @@ let main config =
         raise
           (Ocsigen_config.Config_file_error
              "maxthreads should be greater than minthreads");
-      Lwt_preemptive.init minthreads maxthreads (fun s ->
-        Logs.err ~src:section (fun fmt -> fmt "%s" s));
       (Lwt.async_exception_hook :=
          fun e ->
            (* replace the default "exit 2" behaviour *)
@@ -447,7 +445,6 @@ let start
       ?debugmode
       ?minthreads
       ?maxthreads
-      ?max_number_of_threads_queued
       ?max_number_of_connections
       ?client_timeout
       ?server_timeout
@@ -480,8 +477,6 @@ let start
   Option.iter Ocsigen_config.set_debug debug;
   Option.iter Ocsigen_config.set_minthreads minthreads;
   Option.iter Ocsigen_config.set_maxthreads maxthreads;
-  Option.iter Ocsigen_config.set_max_number_of_threads_queued
-    max_number_of_threads_queued;
   Option.iter Ocsigen_config.set_max_number_of_connections
     max_number_of_connections;
   Option.iter Ocsigen_config.set_client_timeout client_timeout;

--- a/src/server/ocsigen_server.mli
+++ b/src/server/ocsigen_server.mli
@@ -50,7 +50,6 @@ val start :
   -> ?debugmode:bool
   -> ?minthreads:int
   -> ?maxthreads:int
-  -> ?max_number_of_threads_queued:int
   -> ?max_number_of_connections:int
   -> ?client_timeout:int
   -> ?server_timeout:int


### PR DESCRIPTION
`Lwt_preemptive` is not used in any Ocsigen projects and will make less sense with other concurrency libraries.
This removes the call to `Lwt_preemptive.init` and the `maxdetachedcomputationsqueued` config option.