### PR TITLE
test: Fix unstable tests due to date in logs

### DIFF
--- a/test/server-test-helpers.sh
+++ b/test/server-test-helpers.sh
@@ -13,7 +13,7 @@ run_server ()
   mkdir -p log data # Directories that might be required by the server
   dune build "$1"
   # Run the server in the background, cut the datetime out of the log output.
-  dune exec -- "$@" 2>&1 | cut -d ' ' -f 4- &
+  dune exec -- "$@" 2>&1 | cut -b 18- &
   # Wait for the unix-domain socket and the command-pipe to be created
   local timeout=50 # Don't wait more than 0.5s
   while ! ( [[ -e ./local.sock ]] && [[ -e ./local.cmd ]] ) && (( timeout-- > 0 )); do


### PR DESCRIPTION
The `cut` command stripping away the date of log messages broke at the beginning of the month due to using `' '` as a separator. Instead, we can count on the date format to always be 16 characters long and make the `cut` command more robust.