### PR TITLE
Ocsigen_stream: Remove Lwt_stream related functions

### DIFF
--- a/src/baselib/dune
+++ b/src/baselib/dune
@@ -26,6 +26,7 @@
   cryptokit
   re
   ocsigen_lib_base
+  cohttp-lwt
   logs
   (select
    dynlink_wrapper.ml

--- a/src/baselib/ocsigen_stream.ml
+++ b/src/baselib/ocsigen_stream.ml
@@ -239,22 +239,7 @@ let of_lwt_stream stream =
   in
   make aux
 
-(** Convert an {!Ocsigen_stream.t} into a {!Lwt_stream.t}.
-    @param is_empty function to skip empty chunk.
-*)
-let to_lwt_stream ?(is_empty = fun _ -> false) o_stream =
-  let stream = ref (get o_stream) in
-  let rec wrap () =
-    next !stream >>= function
-    | Finished None -> o_stream.finalizer `Success >>= fun () -> Lwt.return None
-    | Finished (Some next) ->
-        stream := next;
-        wrap ()
-    | Cont (value, next) ->
-        stream := next;
-        if is_empty value then wrap () else Lwt.return (Some value)
-  in
-  Lwt_stream.from wrap
+let of_cohttp_body body = Cohttp_lwt.Body.to_stream body |> of_lwt_stream
 
 module StringStream = struct
   type out = string t

--- a/src/baselib/ocsigen_stream.mli
+++ b/src/baselib/ocsigen_stream.mli
@@ -106,13 +106,8 @@ val of_file : string -> string t
 val of_string : string -> string t
 (** returns a stream containing a string. *)
 
-val of_lwt_stream : 'a Lwt_stream.t -> 'a t
+val of_cohttp_body : Cohttp_lwt.Body.t -> string t
 (** Convert a {!Lwt_stream.t} to an {!Ocsigen_stream.t}. *)
-
-val to_lwt_stream : ?is_empty:('a -> bool) -> 'a t -> 'a Lwt_stream.t
-(** Convert an {!Ocsigen_stream.t} into a {!Lwt_stream.t}.
-    @param is_empty function to skip empty chunk.
-*)
 
 module StringStream : sig
   type out = string t

--- a/src/server/ocsigen_multipart.ml
+++ b/src/server/ocsigen_multipart.ml
@@ -365,10 +365,10 @@ let post_params ~content_type body_gen =
   match String.lowercase_ascii ct, String.lowercase_ascii cst with
   | "application", "x-www-form-urlencoded" ->
       Some
-        (body_gen |> Cohttp_lwt.Body.to_stream |> Ocsigen_stream.of_lwt_stream
+        (body_gen |> Ocsigen_stream.of_cohttp_body
        |> post_params_form_urlencoded)
   | "multipart", "form-data" ->
       Some
-        (body_gen |> Cohttp_lwt.Body.to_stream |> Ocsigen_stream.of_lwt_stream
+        (body_gen |> Ocsigen_stream.of_cohttp_body
         |> post_params_multipart_form_data ctparams)
   | _ -> None


### PR DESCRIPTION
On top of https://github.com/ocsigen/ocsigenserver/pull/260, only the last commit is relevant.