### PR TITLE
Upgrade to Cohttp 6.0.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,8 +18,8 @@
  (depends
   (ocaml (>= 4.08.1))
   (camlzip (>= 1.04))
-  (cohttp-lwt-unix (and (>= 5.0) (< 6.0)))
-  (conduit-lwt-unix (and (>= 2.0) (< 7.0)))
+  (cohttp-lwt-unix (>= 6.0))
+  conduit-lwt-unix
   http
   cryptokit
   (ipaddr (>= 2.1))

--- a/ocsigenserver.opam
+++ b/ocsigenserver.opam
@@ -13,8 +13,8 @@ depends: [
   "dune" {>= "3.19"}
   "ocaml" {>= "4.08.1"}
   "camlzip" {>= "1.04"}
-  "cohttp-lwt-unix" {>= "5.0" & < "6.0"}
-  "conduit-lwt-unix" {>= "2.0" & < "7.0"}
+  "cohttp-lwt-unix" {>= "6.0"}
+  "conduit-lwt-unix"
   "http"
   "cryptokit"
   "ipaddr" {>= "2.1"}

--- a/src/server/ocsigen_cohttp.ml
+++ b/src/server/ocsigen_cohttp.ml
@@ -60,10 +60,8 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
   let rec getsockname = function
     | `TCP (ip, port) -> Unix.ADDR_INET (Ipaddr_unix.to_inet_addr ip, port)
     | `Unix_domain_socket path -> Unix.ADDR_UNIX path
-    | `TLS (_, edn) -> getsockname edn
-    | `Unknown err -> raise (Failure ("resolution failed: " ^ err))
-    | `Vchan_direct _ -> raise (Failure "VChan not supported")
-    | `Vchan_domain_socket _ -> raise (Failure "VChan not supported")
+    | `TLS (_, edn) -> getsockname (edn :> Conduit_lwt_unix.endp)
+    | _ -> raise (Failure "resolution failed")
   in
   let sockaddr = getsockname edn in
   let connection_closed =
@@ -157,8 +155,6 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
 
 let conn_closed (_flow, conn) =
   try
-    Logs.debug ~src:section (fun fmt ->
-      fmt "Connection closed:\n%s" (Cohttp.Connection.to_string conn));
     Lwt.wakeup (snd (Hashtbl.find connections conn)) ();
     Hashtbl.remove connections conn;
     decr_connected ()

--- a/test/extensions/deflatemod.t/run.t
+++ b/test/extensions/deflatemod.t/run.t
@@ -21,8 +21,8 @@ First response is not compressed:
   $ curl_ "index.html"
   HTTP/1.1 200 OK
   content-type: text/html
-  server: Ocsigen
   content-length: 12
+  server: Ocsigen
   
   Hello world
 
@@ -31,6 +31,7 @@ Second response is compressed:
   $ curl_ "index.html" --compressed
   HTTP/1.1 200 OK
   content-type: text/html
+  content-length: 12
   content-encoding: gzip
   server: Ocsigen
   transfer-encoding: chunked


### PR DESCRIPTION
This upgrade is needed to be able to target `cohttp-eio` which was added in version 6.0.0.

Cohttp doesn't carry the content encoding in the Response type so some code is added to add the `transfer-encoding` header.