### PR TITLE
Remove usage of Unix.sockaddr type

### DIFF
--- a/src/server/ocsigen_cohttp.ml
+++ b/src/server/ocsigen_cohttp.ml
@@ -58,12 +58,10 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
   let filenames = ref [] in
   let edn = Conduit_lwt_unix.endp_of_flow flow in
   let rec getsockname = function
-    | `TCP (ip, port) -> Unix.ADDR_INET (Ipaddr_unix.to_inet_addr ip, port)
-    | `Unix_domain_socket path -> Unix.ADDR_UNIX path
+    | `TCP (ip, _port) -> Ipaddr.to_string ip
+    | `Unix_domain_socket path -> "unix://" ^ path
     | `TLS (_, edn) -> getsockname edn
-    | `Unknown err -> raise (Failure ("resolution failed: " ^ err))
-    | `Vchan_direct _ -> raise (Failure "VChan not supported")
-    | `Vchan_domain_socket _ -> raise (Failure "VChan not supported")
+    | `Unknown _ | `Vchan_direct _ | `Vchan_domain_socket _ -> "unknown"
   in
   let sockaddr = getsockname edn in
   let connection_closed =

--- a/src/server/ocsigen_request.mli
+++ b/src/server/ocsigen_request.mli
@@ -19,7 +19,7 @@ val make :
   -> port:int
   -> ssl:bool
   -> filenames:string list ref
-  -> sockaddr:Lwt_unix.sockaddr
+  -> sockaddr:string
   -> body:Cohttp_lwt.Body.t
   -> connection_closed:unit Lwt.t
   -> Cohttp.Request.t

--- a/src/server/ocsigen_server.ml
+++ b/src/server/ocsigen_server.ml
@@ -38,19 +38,6 @@ let () =
         ("Uncaught Exception after lwt timeout" ^^ "@\n%s")
         (Printexc.to_string e)))
 
-let pp_sockaddr ppf = function
-  | Unix.ADDR_INET (ip, _port) ->
-      Format.fprintf ppf "%s" (Unix.string_of_inet_addr ip)
-  | ADDR_UNIX f -> Format.fprintf ppf "%s" f
-
-let _warn sockaddr s =
-  Logs.warn ~src:section (fun fmt ->
-    fmt "While talking to %a:%s" pp_sockaddr sockaddr s)
-
-let _dbg sockaddr s =
-  Logs.info ~src:section (fun fmt ->
-    fmt "While talking to %a:%s" pp_sockaddr sockaddr s)
-
 (* fatal errors messages *)
 let errmsg = function
   | Dynlink_wrapper.Error e ->


### PR DESCRIPTION
This makes `Ocsigen_request.t` lighter and remove a source of exceptions.

Value of type `Unix.sockaddr` were constructed for purposes other than performing network calls and can easily be replaced by a string.

Accesscontrol is the only user of parsed IP addresses, which doesn't justifies the weight added to the request record.
This removes a source of exception for every requests.