### PR TITLE
test: Fix unstable log output due to User-agent

### DIFF
--- a/test/extensions/deflatemod.t/run.t
+++ b/test/extensions/deflatemod.t/run.t
@@ -1,14 +1,14 @@
   $ source ../../server-test-helpers.sh
   $ run_server ./test.exe
   ocsigen:main: [WARNING] Command pipe created
-  ocsigen:access:  connection for local-test from  (curl/8.12.1): /index.html
+  ocsigen:access:  connection for local-test from  (): /index.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./index.html".
   ocsigen:local-file: [INFO] checking if file index.html can be sent
   ocsigen:ext: [INFO] Compiling exclusion regexp $^
   ocsigen:local-file: [INFO] Returning "./index.html".
-  ocsigen:access:  connection for local-test from  (curl/8.12.1): /index.html
+  ocsigen:access:  connection for local-test from  (): /index.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./index.html".

--- a/test/server-test-helpers.sh
+++ b/test/server-test-helpers.sh
@@ -37,6 +37,7 @@ curl_ ()
 {
   local path=$1; shift
   # Remove the 'date' header, which is unreproducible
-  curl --unix-socket ./local.sock -s -i "$@" "http://local-test/$path" | \
+  curl --unix-socket ./local.sock --user-agent "" -s -i \
+    "$@" "http://local-test/$path" | \
     grep -v "^date: "
 }


### PR DESCRIPTION
Curl sets a User-agent value that changes with each version and causes unwanted diffs in log outputs.