### PR TITLE
Alternative API for `Ocsigen_request.remote_ip`

### DIFF
--- a/src/extensions/revproxy.ml
+++ b/src/extensions/revproxy.ml
@@ -109,7 +109,7 @@ let gen dir = function
                        (Ocsigen_request.address request_info)
                    in
                    String.concat ", "
-                     (Ocsigen_request.remote_ip request_info
+                     (Ocsigen_request.client_conn_to_string request_info
                       :: Ocsigen_request.forward_ip request_info
                      @ [address])
                  in

--- a/src/server/ocsigen_cohttp.ml
+++ b/src/server/ocsigen_cohttp.ml
@@ -57,15 +57,13 @@ end
 let handler ~ssl ~address ~port ~connector (flow, conn) request body =
   let filenames = ref [] in
   let edn = Conduit_lwt_unix.endp_of_flow flow in
-  let rec getsockname = function
-    | `TCP (ip, port) -> Unix.ADDR_INET (Ipaddr_unix.to_inet_addr ip, port)
-    | `Unix_domain_socket path -> Unix.ADDR_UNIX path
-    | `TLS (_, edn) -> getsockname edn
-    | `Unknown err -> raise (Failure ("resolution failed: " ^ err))
-    | `Vchan_direct _ -> raise (Failure "VChan not supported")
-    | `Vchan_domain_socket _ -> raise (Failure "VChan not supported")
+  let client_conn =
+    match edn with
+    | `TCP (ip, port) | `TLS (_, `TCP (ip, port)) -> `Inet (ip, port)
+    | `Unix_domain_socket path | `TLS (_, `Unix_domain_socket path) ->
+        `Unix path
+    | _ -> `Unknown
   in
-  let sockaddr = getsockname edn in
   let connection_closed =
     try fst (Hashtbl.find connections conn)
     with Not_found ->
@@ -110,7 +108,7 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
   in
   (* TODO: equivalent of Ocsigen_range *)
   let request =
-    Ocsigen_request.make ~address ~port ~ssl ~filenames ~sockaddr ~body
+    Ocsigen_request.make ~address ~port ~ssl ~filenames ~client_conn ~body
       ~connection_closed request
   in
   Lwt.finalize
@@ -120,7 +118,7 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
             (match Ocsigen_request.host request with
             | None -> "<host not specified in the request>"
             | Some h -> h)
-            (Ocsigen_request.remote_ip request)
+            (Ocsigen_request.client_conn_to_string request)
             (Option.value ~default:""
                (Ocsigen_request.header request Ocsigen_header.Name.user_agent))
             (Option.fold ~none:""

--- a/test/extensions/deflatemod.t/run.t
+++ b/test/extensions/deflatemod.t/run.t
@@ -1,14 +1,14 @@
   $ source ../../server-test-helpers.sh
   $ run_server ./test.exe
   ocsigen:main: [WARNING] Command pipe created
-  ocsigen:access:  connection for local-test from  (): /index.html
+  ocsigen:access:  connection for local-test from unix: (): /index.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./index.html".
   ocsigen:local-file: [INFO] checking if file index.html can be sent
   ocsigen:ext: [INFO] Compiling exclusion regexp $^
   ocsigen:local-file: [INFO] Returning "./index.html".
-  ocsigen:access:  connection for local-test from  (): /index.html
+  ocsigen:access:  connection for local-test from unix: (): /index.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./index.html".


### PR DESCRIPTION
This improve the API for querying the client's connection info, which makes less sense since the added support for unix domain sockets.

The `client_conn` type no longer loose connection information:
- The client port is available.
- Failure points are removed in favor of a `` `Unknown `` case

The `` `Forwarded_for `` case makes sure that IP addresses reported through the `x_forwarded_for` HTTP header can't be used by `Accesscontrol` by mistake.

There are two API for this information:
- `client_conn_to_string`: Returns the information in textual form for when the data don't need to be parsed back. For example, ideal in log messages. It's also used to set the `x_forwarded_for` header, where using a wrong format is better than inventing data in cases where we don't use Internet.
- `client_conn`: The full data without superfluous transformations.

An other change is that the client IP address doesn't go through `getaddrinfo` (via `Ipaddr_unix.to_inet_addr`). This doesn't change anything in the general case but might remove a potential exploit on servers where `/etc/hosts` is compromised.

This is a second attempt at https://github.com/ocsigen/ocsigenserver/pull/270 which was partially reverted because the API name was bad. This new attempt is also free of workarounds and conversions to and from `Unix.inet_addr`.