### PR TITLE
Fix wrong `transfer-encoding` headers being sent

### DIFF
--- a/src/server/ocsigen_response.mli
+++ b/src/server/ocsigen_response.mli
@@ -23,11 +23,15 @@ val make :
   -> ?cookies:Ocsigen_cookie_map.t
   -> Cohttp.Response.t
   -> t
+(** Make a response from a [Cohttp.Response.t]. Note that the
+    [transfer-encoding] header is not taken into account if it is set to
+    [chunked], use {!add_header}. This is because [Cohttp.Response.make] sets
+    this header by default, which interferes with the transfer-encoding carried
+    by the [body]. *)
 
 val respond :
    ?headers:Cohttp.Header.t
   -> status:Http.Status.t
-  -> encoding:Cohttp.Transfer.encoding
   -> ?body:Body.t
   -> unit
   -> t

--- a/test/extensions/deflatemod.t/run.t
+++ b/test/extensions/deflatemod.t/run.t
@@ -14,13 +14,13 @@
   ocsigen:local-file: [INFO] Testing "./index.html".
   ocsigen:local-file: [INFO] checking if file index.html can be sent
   ocsigen:local-file: [INFO] Returning "./index.html".
-  ocsigen:access:  connection for local-test from unix:// (): /empty_dir/
+  ocsigen:access:  connection for local-test from unix: (): /empty_dir/
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./empty_dir/".
   ocsigen:local-file: [INFO] Testing "./empty_dir/index.html" as possible index.
   ocsigen:local-file: [INFO] No index and no listing
-  ocsigen:access:  connection for local-test from unix:// (): /doesnt_exists.html
+  ocsigen:access:  connection for local-test from unix: (): /doesnt_exists.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./doesnt_exists.html".
@@ -31,8 +31,8 @@ First response is not compressed:
   $ curl_ "index.html"
   HTTP/1.1 200 OK
   content-type: text/html
-  content-length: 12
   server: Ocsigen
+  content-length: 12
   
   Hello world
 
@@ -41,7 +41,6 @@ Second response is compressed:
   $ curl_ "index.html" --compressed
   HTTP/1.1 200 OK
   content-type: text/html
-  content-length: 12
   content-encoding: gzip
   server: Ocsigen
   transfer-encoding: chunked
@@ -53,13 +52,13 @@ compression:
 
   $ mkdir empty_dir && curl_ empty_dir/ --compressed
   HTTP/1.1 404 Not Found
-  content-length: 16
   server: Ocsigen
+  content-length: 16
   
   Error: Not Found
   $ curl_ doesnt_exists.html --compressed
   HTTP/1.1 404 Not Found
-  content-length: 16
   server: Ocsigen
+  content-length: 16
   
   Error: Not Found


### PR DESCRIPTION
`Ocsigen_response` carries a `Cohttp.Response.t` and a `body` and both of them carry a `transfer-encoding`.
The problem is that the `Cohttp.Response.t` is often constructed with a default value for the transfer encoding that takes precedence over the encoding of the body.

This changes `Ocsigen_response.make` to remove the header if it is equal to the default value. The correct way to specify the encoding is while constructing the `Body.t` value. Setting the header with `Ocsigen_response.add_header` is also supported.

This bug could materialize with pages that never finish loading or with trimmed content.
Especially in Eliom, where `Cohttp.Response.make` is often called without the `~encoding` argument.

This bug was introduced in https://github.com/ocsigen/ocsigenserver/pull/260 while introducing the `Body.t` type.