### PR TITLE
Control the log level of all Ocsigen log sources

### DIFF
--- a/src/baselib/ocsigen_lib_base.ml
+++ b/src/baselib/ocsigen_lib_base.ml
@@ -285,6 +285,19 @@ module String_base = struct
       else n
     with Invalid_argument _ -> n
 
+  (* Copied from the stdlib. TODO: Remove once the minimum OCaml version is at
+     least 4.13. *)
+  let starts_with ~prefix s =
+    let len_s = length s and len_pre = length prefix in
+    let rec aux i =
+      if i = len_pre
+      then true
+      else if unsafe_get s i <> unsafe_get prefix i
+      then false
+      else aux (i + 1)
+    in
+    len_s >= len_pre && aux 0
+
   module Table = Map.Make (String)
   module Set = Set.Make (String)
   module Map = Map.Make (String)

--- a/src/baselib/ocsigen_lib_base.mli
+++ b/src/baselib/ocsigen_lib_base.mli
@@ -129,6 +129,9 @@ module String_base : sig
       removing spaces.
       For ex "azert,   sdfmlskdf,    dfdsfs". *)
 
+  val starts_with : prefix:string -> string -> bool
+  (** Same as {!Stdlib.String.starts_with}. *)
+
   val may_append : string -> sep:string -> string -> string
   (* WAS add_to_string *)
 

--- a/src/server/ocsigen_config.ml
+++ b/src/server/ocsigen_config.ml
@@ -40,6 +40,14 @@ end
 
 type socket_type = Socket_type.t
 
+let set_global_log_level lvl =
+  let open Logs.Src in
+  List.iter
+    (fun src ->
+       if String.starts_with ~prefix:"ocsigen:" (name src)
+       then set_level src lvl)
+    (list ())
+
 (* General config *)
 let verbose = ref false
 let silent = ref false
@@ -82,12 +90,12 @@ let set_syslog_facility f =
 let set_configfile s = config_file := s
 let set_pidfile s = pidfile := Some s
 let set_mimefile s = mimefile := s
-let () = Logs.set_level ~all:true (Some Logs.Warning)
+let () = set_global_log_level (Some Logs.Warning)
 (* without --verbose *)
 
 let set_verbose () =
   verbose := true;
-  Logs.set_level ~all:true (Some Logs.Warning)
+  set_global_log_level (Some Logs.Warning)
 
 let set_silent () = silent := true
 
@@ -98,13 +106,13 @@ let set_daemon () =
 let set_veryverbose () =
   verbose := true;
   veryverbose := true;
-  Logs.set_level ~all:true (Some Logs.Info)
+  set_global_log_level (Some Logs.Info)
 
 let set_debug () =
   verbose := true;
   veryverbose := true;
   debug := true;
-  Logs.set_level ~all:true (Some Logs.Debug)
+  set_global_log_level (Some Logs.Debug)
 
 let set_minthreads i = minthreads := i
 let set_maxthreads i = maxthreads := i

--- a/src/server/ocsigen_config.mli
+++ b/src/server/ocsigen_config.mli
@@ -38,6 +38,11 @@ type socket_type = Socket_type.t
 
 exception Config_file_error of string
 
+val set_global_log_level : Logs.level option -> unit
+(** Set the log level for all Ocsigen log sources. Using this function is
+    preferable to using [Logs.set_level] directly to avoid the excessive logging
+    from Cohttp and let you use a different log level for your application. *)
+
 val server_name : string
 val full_server_name : string
 val version_number : string

--- a/test/extensions/deflatemod.t/test.ml
+++ b/test/extensions/deflatemod.t/test.ml
@@ -1,6 +1,5 @@
 let () =
-  Logs.Src.set_level Deflatemod.section (Some Logs.Debug);
-  Logs.set_level ~all:true (Some Logs.Debug);
+  Ocsigen_config.set_global_log_level (Some Logs.Debug);
   Ocsigen_server.start
     ~ports:[ (`Unix "./local.sock", 0) ]
     ~veryverbose:() ~debugmode:true ~logdir:"log" ~datadir:"data"


### PR DESCRIPTION
Fix https://github.com/ocsigen/ocsigenserver/issues/279

This adds `Ocsigen_config.set_global_log_level` to set the log level for
all ocsigen sources. The `verbose`, `veryverbose` and `debug` option use
this new function instead of `Logs.set_level ~all:true`.

The main goal is to not see cohttp's debug logs, which are excessively
verbose. The added benefit is that it's now easier to use a different
log level for the application, ocsigen libraries and third party
libraries.
