### PR TITLE
doc: manual + API as odoc pages (dev / modernize)

### DIFF
--- a/doc/accesscontrol.mld
+++ b/doc/accesscontrol.mld
@@ -1,0 +1,121 @@
+{0 Accesscontrol}
+
+{1 The accesscontrol extension}
+
+If you want to restrict access for some sites, this extension is for you.
+
+{1 Loading the extension}
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.accesscontrol],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+
+{v
+<extension findlib-package="ocsigenserver.ext.accesscontrol"/>
+v}
+
+
+Here, we call {e actions} elements that can be put in a site configuration. Actions include [<eliom>], [<static>], etc.
+This extension defines several actions.
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Accesscontrol}.
+
+{1 The [<if>] action}
+
+It takes as children a condition followed by a [<then>] element and possibly an [<else>] element. When a request reaches an [<if>], if the condition evaluates to true, then the whole [<if>] behaves as if it had been replaced by the contents of the [<then>] element, otherwise it behaves as if it had been replaced by the contents of the [<else>] element. A missing [<else>] is considered as an [<else>] with no children.
+
+{2 Conditions}
+
+Atomic conditions:
+
+- [<ip value="..." />]: [value] can be an IPv4 or IPv6 address, with an optional [/n] suffix indicating a subnet mask; true if the IP address of the client matches [value].
+- [<port value="..." />]: [value] can be a number; true if the request was received on port [value]. (new in 1.2)
+- [<ssl/>]: true if the request was received by HTTPS. (new in 1.2)
+- [<header name="..." regexp="..." />]: true if the header of the request has a [name] field that matches [regexp].
+- [<method value="..." />]: true if the HTTP method ([GET], [POST], etc) of the request is [value].
+- [<protocol value="..." />]: [value] can be [HTTP/1.0] or [HTTP/1.1]; true if the protocol specified in the request is [value].
+- [<path regexp="..." />]: true if the part of the path concerning the site matches [regexp].
+
+Combining conditions (all their children must be conditions):
+
+- [<and>...</and>]: true if all enclosed conditions are true (true if empty).
+- [<or>...</or>]: true if one of the enclosed conditions is true (false if empty).
+- [<not>...</not>]: true if the enclosed condition is false (there must be exactly one enclosed condition).
+
+{1 Other actions}
+
+- [<notfound/>]: stops immediately (does not try other sites) with a 404 error.
+- [<forbidden/>]: stops immediately (does not try other sites) with a 403 error.
+- [<iffound>...</iffound>]: tries the enclosed actions if some action has already answered.
+- [<ifnotfound code="...">...</ifnotfound>]: tries the enclosed actions if noone has answered so far. [code] is an optional regexp matching the current error code.
+- [<nextsite/>]: stops parsing current site. If the page has been found, answer. If not, try next site. {e from Ocsigen 1.2}
+- [<nexthost/>]: stops parsing current host. If the page has been found, answer. If not, try next host. {e from Ocsigen 1.2}
+- [<stop/>]: stops parsing configuration file (answers now whether the page has been found or not). {e from Ocsigen 1.2}
+- [<allow-forward-for/>]: if there is an X-Forwarded-For header in the request, the information of the request is changed to match the announced ip.
+- [<allow-forward-proto/>]: if the X-Forwarded-Proto header is set to https (http), the connection is considered as secured (unsecure) even if the connection is not in ssl (is in ssl).
+
+{1 Examples}
+
+- I want some actions to handle only requests from localhost, for users using the browser Konqueror:
+{v
+<if>
+  <and>
+    <ip value="127.0.0.1" />
+    <header name="user-agent" regexp=".*Konqueror.*" />
+  </and>
+  <then>
+    <!-- put your actions here -->
+  </then>
+</if>
+v}
+Or, if you are using Ocsigen Server as a library:
+{@ocaml[
+Accesscontrol.(if_ (and_ [(ip "127.0.0.1"); 
+                          (header ~name:"user-agent" ~regexp:".*Konqueror.*")])
+                  [ ... ]
+                  [])
+]}
+
+
+- I want some actions to handle requests that respect at least one of the following conditions:
+- they belong to the subnet 123.123.123.0/24,
+- or they want to access a page beginning with the letter 'c',
+- or they are not doing a [GET HTTP] request:
+{v
+<if>
+  <or>
+    <ip value="123.123.123.0/24" />
+    <path regexp="/c.*" />
+    <not><method value="GET" /></not>
+  </or>
+  <then>
+    <!-- put your actions here -->
+  </then>
+</if>
+v}
+Or, if you are using Ocsigen Server as a library:
+{@ocaml[
+Accesscontrol.(if_ (or_ [(ip "123.123.123.0/24"); 
+                         (path ~regexp:"/c.*");
+                         (not_ (method_ `GET))])
+                  [ ... ]
+                  [])
+]}
+
+- I want to deny access to 192.168.0.0/24 except 192.168.0.42, and to 192.168.99.0/24:
+{v
+<if>
+  <or>
+    <and>
+      <ip value="192.168.0.0/24" />
+      <not><ip value="192.168.0.42" /></not>
+    </and>
+    <ip value="192.168.99.0/24" />
+  </or>
+  <then>
+    <forbidden/>
+  </then>
+</if>
+v}

--- a/doc/api.mld
+++ b/doc/api.mld
@@ -1,0 +1,52 @@
+{0 API reference}
+
+API reference for Ocsigen Server. See the {{!page-quickstart}manual} to get
+started.
+
+{!modules:
+Ocsigen.Server
+}
+
+{2 Extensions}
+
+{!modules:
+Staticmod
+Extendconfiguration
+Accesscontrol
+Authbasic
+Deflatemod
+Redirectmod
+Revproxy
+Rewritemod
+Outputfilter
+Userconf
+Cors
+}
+
+{2 Requests, responses, configuration, logging}
+
+{!modules:
+Ocsigen.Request
+Ocsigen.Response
+Ocsigen.Config
+Ocsigen.Messages
+Ocsigen.Parseconfig
+Ocsigen.Multipart
+Ocsigen.Command
+}
+
+{2 Extending Ocsigen Server}
+
+{!modules:
+Ocsigen.Extensions
+Ocsigen.Local_files
+}
+
+{2 Base library}
+
+{!modules:
+Lib
+Polytables
+Cache
+Ocsigen_stream
+}

--- a/doc/authbasic.mld
+++ b/doc/authbasic.mld
@@ -1,0 +1,52 @@
+{0 Authbasic}
+
+This module  implements Basic HTTP Authentication as  described in RFC
+2617. It can  be used to add an authentication layer  to sites with no
+built-in authentication (e.g. static files).
+
+Beware, passwords  are transmitted in  cleartext with this  scheme, so
+the  medium should  be  secured  somehow (by  e.g.  SSL).
+
+This  module
+implements only the HTTP-related part of the protocol, and is meant to
+be extended with  various authentication plugins.
+
+A very  naive one is
+provided as an example. See  the developer's documentation if you want
+to make your own one.
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.authbasic],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+{v
+<extension findlib-package="ocsigenserver.ext.authbasic"/>
+v}
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Authbasic}.
+
+This extension defines one action, [<authbasic>],
+and one authentication plugin, [<plain>].
+
+{1 The [<authbasic>] action}
+To add an authentication layer to a site, add the following lines before the actions defining the restricted part of your site:
+{v
+<authbasic realm="...">
+   ...
+</authbasic>
+v}
+The realm attribute is some name identifying the protected resource. The client is expected to send the same authentication info to all pages protected with the same realm on the same hostname.
+
+When a request containing the right authentication token arrives, this action doesn't do anything (and therefore grants access). If the authentication info is missing, an HTTP 401 Unauthorized is immediately returned (no other extension is tried) to request the client to provide this authentication token. On most interactive browsers, this is done by popping up a dialog box asking the user for a login and a password.
+
+The [<authbasic>] element expects one child element,
+specifying which authentication plugin to use.
+
+{1 The [<plain>] plugin}
+To protect a resource with some fixed login and password given in the configuration file, you can use the [<plain>] plugin. Here is a self-contained example:
+{v
+<authbasic realm="example">
+   <plain login="me" password="mypassword" />
+</authbasic>
+v}

--- a/doc/config.mld
+++ b/doc/config.mld
@@ -1,0 +1,687 @@
+
+{0 Configuration file}
+  
+
+
+The main configuration file is usually named
+[/etc/ocsigenserver/ocsigenserver.conf]. It contains the port(s) on
+which you want to run the server (usually 80), the protocol to use
+(HTTP or HTTPS), the location of log files, many settings for the
+server, the extensions to be loaded, the OCaml libraries you need for
+your Web sites, the configuration of each Web site, etc. One default
+configuration file should be provided by your distribution.
+
+{2 Basic layout of the configuration file}
+
+The configuration file is an XML file. Its layout is the following:
+
+{v
+<ocsigen>
+
+  <server>
+
+    <!-- General setting -->
+    <port>80</port>
+
+    <logdir>...</logdir>
+    <datadir>...</datadir>
+    <commandpipe>...</commandpipe>
+
+    <!-- Extensions to be loaded: -->
+    <extension module=.../>
+    <extension module=...>
+      <!-- Options for the extension -->
+      ...
+    </extension>
+
+    <!-- You can also use Findlib to load an extension and its dependencies: -->
+    <findlib path=.../>
+    <extension findlib-package=.../>
+
+    <!-- Libraries needed by Web sites: -->
+    <require module=.../> <!-- <require is equivalent to <extension> -->
+    <require findlib-package=.../>
+    <require module=...>
+      <!-- Options for the library -->
+      ...
+    </require>
+
+    <!-- Libraries needed by Web sites, when you want them to be reloaded
+         every times you reload the config files: -->
+    <library module=.../>
+    <library findlib-package=.../>
+    <library module=...>
+      <!-- Options for the library -->
+      ...
+    </library>
+
+    <!-- Inclusion of all external configuration files matching *.conf
+     from this directory (in alphabetical order): -->
+    <extconf dir=... />
+
+    <!-- Virtual hosts configuration: -->
+    <host defaulthostname=... hostfilter=...>
+
+      <!-- configuration for the site at the root -->
+      ...
+
+      <site path=...>
+        <!-- configuration for the first sub-site -->
+        <!-- Warning: it was <site dir=...> before 0.99.4 -->
+        ...
+      </site>
+
+      <site path=...>
+        <!-- configuration for another sub-site -->
+        ...
+      </site>
+    </host>
+
+    <host defaulthostname=... hostfilter=...>
+      <!-- configuration for the second virtual host -->
+      ...
+    </host>
+
+    ...
+
+  </server>
+
+</ocsigen>
+v}
+
+Here is a simple example:
+
+{v
+<ocsigen>
+  <server>
+
+    <port>127.0.0.1:80</port>
+
+    <logdir>/var/log/ocsigenserver</logdir>
+    <datadir>/var/lib/ocsigenserver</datadir>
+    <commandpipe>/var/run/ocsigenserver/command</commandpipe>
+
+    <user>www-data</user>
+    <group>www-data</group>
+
+    <charset>utf-8</charset>
+
+    <extension findlib-package="ocsigenserver.ext.staticmod"/>
+
+    <extension findlib-package="ocsigenserver.ext.ocsipersist-sqlite"/>
+    <!-- sqlite3.cma will be loaded automatically using findlib -->
+
+    <extension findlib-package="eliom.server"/>
+    <!-- Eliom's dependencies will be loaded automatically using findlib -->
+
+    <extconf dir="/etc/ocsigenserver/conf.d" />
+
+    <host charset="utf-8" hostfilter="www.mywonderfulwebsite.org">
+
+      <static dir="/var/www/ocsigenserver" />
+
+      <site path="tuto">
+        <eliom module="/usr/local/lib/ocaml/tutoeliom/tutoeliom.cmo" />
+        <static dir="/var/www/tutorial" />
+      </site>
+
+    </host>
+
+  </server>
+
+</ocsigen>
+v}
+
+Here is another example, for use as unprivileged user toto on port 8000.
+We use the PostgreSQL (version >= 9.5) backend for ocsipersist. Note that the
+ocsipersist-database under the specified name (default: "ocsipersist") needs to
+exist. To create it run [psql] and execute [CREATE TABLE ocsipersist;].
+
+{v
+<ocsigen>
+  <server>
+
+    <port>8000</port>
+
+    <logdir>/home/toto/var/log/ocsigenserver</logdir>
+    <datadir>/home/toto/var/lib/ocsigenserver</datadir>
+    <commandpipe>/home/toto/var/run/ocsigenserver_command</commandpipe>
+
+    <user>toto</user>
+    <group>toto</group>
+
+    <charset>utf-8</charset>
+
+    <extension findlib-package="ocsigenserver.ext.staticmod"/>
+
+    <extension findlib-package="ocsigenserver.ext.ocsipersist-pgsql">
+      <database <!-- optional, as each of the following attributes are -->
+        port="3000"
+        user="toto"
+        password="toto's secret"
+      />
+    </extension>
+    <!-- pa_pgsql.cma will be loaded automatically using findlib -->
+
+    <extension findlib-package="ocsigenserver.ext.eliom"/>
+    <!-- Eliom's dependencies will be loaded automatically using findlib -->
+
+    <extconf dir="/home/toto/etc/ocsigenserver/conf.d" />
+
+    <host>
+
+      <static dir="/home/toto/var/www/ocsigenserver" />
+
+      <site path="tuto">
+        <eliom module="/usr/local/lib/ocsigenserver/tutoeliom.cmo" />
+        <static dir="/home/toto/var/www/ocsigenserver/tutorial" />
+        <!-- Module's path coul be relative but static dir must be absolute -->
+      </site>
+
+    </host>
+
+  </server>
+
+</ocsigen>
+v}
+
+{2 Details about settings}
+
+{3 [<port>] : port and protocol}
+
+
+The port on which the server is listening. You can have several [<port>]lines if you want to listen on several ports.
+
+[<port>] has one optional attribute called [protocol]. Its value may be either  [HTTP] (default) or [HTTPS] if you want to use HTTPS on that port. The default port is 80 for HTTP, and 443 for HTTPS.
+
+You can make the server bind on a specific address:
+
+{v
+    <port>127.0.0.1:80</port>
+v}
+
+To make the server listen on all IPv4 interfaces (and only them):
+
+{v
+    <port>*:80</port>
+v}
+
+To make the server listen on all IPv6 interfaces (and only them):
+{v
+    <port>[::]:80</port>
+v}
+
+To make the server listen on all IPv4 and IPv6 interfaces:
+{v
+   <port>80</port>
+v}
+
+{b Warning:} with versions < 1.3.1, the two previous variants were equivalent and would make the server listen on all IPv6 interfaces, and on IPv4 interfaces as well depending on the operating system (more specifically, the default value of IPV6_V6ONLY). This OS-dependent behaviour has been fixed in version 1.3.1.
+
+You can also make the server bind on a specific IPv6 address (it must be between brackets):
+
+{v
+    <port>[2001:660:3001:4002::10]:80</port>
+v}
+
+If you want to use HTTPS, you need to specify a certificate to use, and a private key, as follows:
+
+{v
+    <ssl>
+       <certificate>path_to/cert.pem</certificate>
+       <privatekey>path_to/privkey.pem</privatekey>
+    </ssl>
+v}
+
+Use the tools provided by openssl to create a 1024-bit private key to use when creating your CA.:
+
+{v
+    openssl genrsa -des3 -out privkey.pem 1024
+v}
+
+To create a master certificate based on this key, to use when signing other certificates:
+
+{v
+    openssl req -new -x509 -days 1001 -key privkey.pem -out cert.pem
+v}
+
+If you don't want to be asked for a password at start-up, you can uncrypt the private key (if you consider it is safe ...):
+
+{v
+    openssl rsa -in privkey.pem -out privkey-unsec.pem
+v}
+
+
+{3 [<logdir>] : log files directory}
+
+
+The directory for log files. Usually [/var/log/ocsigenserver]. Ocsigenserver is using three log files: [access.log] where all requests are logged, [errors.log] for error messages, and [warnings.log] for warnings.
+
+Example :
+
+
+
+{v
+<logdir>/var/log/ocsigenserver</logdir>
+v}
+{3 [<datadir>] : directory for server data}
+
+
+This directory is used to store data used by the server or extensions (for example persistent data). Usually [/var/lib/ocsigenserver].
+
+Example :
+
+
+
+{v
+<datadir>/var/lib/ocsigenserver</datadir>
+v}
+
+{3 [<syslog>] : log to syslog}
+
+Specifies which syslog facility to use, instead of logging to files. This option
+is mutually exclusive with <logdir>.
+
+Example:
+
+{v
+<syslog>Local7</syslog>
+v}
+
+{3 [<user>] and [<group>] : user who runs the server}
+
+
+If the server is launched by root, it will change itself the user and group for the process, for security reasons. Create a group and a user for Ocsigenserver or use an existing user of your system (e.g. [www-data]).
+
+Example :
+
+
+
+{v
+<user>www-data</user>
+<group>www-data</group>
+v}
+{3 [<charset>] : default charset for pages}
+
+
+Example:
+
+
+
+{v
+<charset>utf-8</charset>
+v}
+
+{3:upload [<uploaddir>] : directory where files are uploaded}
+
+
+If you want to allow the users to upload files on the server, add this option.
+
+Example:
+
+{v
+<uploaddir>/var/upload</uploaddir>
+v}
+
+
+By default, no directory is specified and uploading is forbidden. Note that the server will remove the files after the request has been served. If the service (the script) want to keep the file, it must create a new hard link on the file itself.
+
+You can specify the maximum size of uploaded files using [<maxuploadfilesize>]. For example :
+
+{v
+<maxuploadfilesize>2MB</maxuploadfilesize>
+v}
+
+The value may be "infinity" or written using SI or binary units, e.g. 10 10B 10kB 10kiB 10MiB 10TB ... (or 10o 10ko ...) (default in bytes
+                    when no unit is specified)
+
+{e Warning:} the maximum size of files is also limited by [<maxrequestbodysize>].
+
+Starting from Ocsigenserver 1.3, you can redefine the options [<uploaddir>] and [<maxuploadfilesize>] on each host or inside [<site>] tags. The syntax is the same
+as above. There are however some limitations; please read carefully the documentation of the module {{!page-"extendconfiguration".upload}Extendconfiguration} before using this functionality.
+
+
+{3 [<maxrequestbodysize>] : maximum size of the body of incoming requests}
+
+Example:
+{v
+<maxrequestbodysize>100MB</maxrequestbodysize>
+v}
+
+The value may be "infinity" or written using SI or binary units, e.g. 10 10B 10kB 10kiB 10MiB 10TB ... (or 10o 10ko ...) (default in bytes
+                    when no unit is specified)
+
+
+{3 [<mimefile>] : MIME type file}
+
+
+The file associating file name extensions to their MIME type. Example:
+
+
+
+{v
+<mimefile>/etc/ocsigenserver/mime.types</mimefile>
+v}
+
+{3 [<debugmode/>] : Error messages in pages}
+Use this option for debugging your Web sites. Full error messages will be written in Error 500 pages. Example:
+
+{v
+<debugmode/>
+v}
+{3 [<usedefaulthostname/>] : Do not trust Host HTTP header for absolute links}
+
+
+{e (From Ocsigenserver 1.2) }Use this option if you do not trust the Host HTTP header for building absolute links, CGI scripts and redirections. The default hostname set in the configuration file will be used instead. (Same as Apache's UseCanonicalName option). Example:
+
+
+
+{v
+<usedefaulthostname/>
+v}
+{3 [<maxconnected>] : Maximum number of simultaneous connections}
+
+
+Example:
+
+
+
+{v
+<maxconnected>500</maxconnected>
+v}
+{3 [<timeout>] : Timeout for connections}
+
+
+Written in seconds. If the client does not say anything during that amount of time, the connection will be closed. Example:
+
+
+
+{v
+<timeout>20</timeout>
+v}
+{3 [<keepalivetimeout>] : Timeout for Keep-Alive}
+
+
+Amount of time (in seconds) the server will wait for subsequent requests on a persistent connection. Example:
+
+
+{v
+<keepalivetimeout>10</keepalivetimeout>
+v}
+
+{3 [<shutdowntimeout>] : Timeout for graceful shutdown {e From version 1.3}}
+
+
+Amount of time (in seconds) the server will wait for current requests to terminate before ending the process, when you use the "graceful shutdown" server command (see below).
+
+{v
+<shutdowntimeout>10</shutdowntimeout>
+v}
+
+Other possible value: [notimeout] if you don't want to wait all connections even if it takes time.
+
+{3 [<netbuffersize>] : Size of the input buffer}
+
+
+Size of the input buffer (sockets). It is also the maximum size of headers and post data. Example:
+
+
+
+{v
+<netbuffersize>8192B</netbuffersize>
+v}
+{3 [<filebuffersize>] : Size of the buffer for sending files}
+
+
+Size of the buffer for reading files to send. Example:
+
+
+
+{v
+<filebuffersize>8192B</filebuffersize>
+v}
+{3 [<minthreads> <maxthreads>] : Size of the preemptive thread pool}
+
+
+Even if Ocsigenserver is implemented with cooperative threads, web site programmers may want to detach some computation to other preemptive threads. To do that, Ocsigenserver has a pool of preemptive threads running, waiting for computation to do. This options allow to set the size of this pool. Example:
+
+
+
+{v
+<minthreads>10</minthreads>
+<maxthreads>1000</maxthreads>
+v}
+{3 [<maxdetachedcomputationsqueued>] : Size of the queue of waiting detached computations}
+
+
+If the pool of preemptive threads is full, new detached computations will wait for one thread to become available. This is the size of the waiting queue. Only integer values allowed here. Example:
+
+
+
+{v
+<maxdetachedcomputationsqueued>100</maxdetachedcomputationsqueued>
+v}
+{3 [<maxretries>] : Maximum number of retries for the same request}
+
+
+To prevent looping requests, for example after a rewrite of the request, the number of retries is limited to this number. Example:
+
+
+
+{v
+<maxretries>10</maxretries>
+v}
+{3 [<commandpipe>] : The pipe used to give orders to the server}
+
+
+Ocsigenserver is waiting for orders on a pipe. Write the orders on the pipe. This option allows to set the name of the pipe. Example:
+
+
+
+{v
+<commandpipe>/var/run/ocsigenserver_command</commandpipe>
+v}
+
+Each extension can define its own orders.
+
+Predefined orders:
+- [reload]: will reload the configuration file. Extensions will not be reloaded but all other modules will be reloaded (for example Eliom web sites) {e (see below for more information)}.
+- [gc]: will trigger a heap compaction
+- [shutdown]: will shutdown the server when all the current rerquests are fulfilled {e (see below for more information)}
+- [reopen_logs]: will reopen the logs files (see logrotate configuration for an example of use)
+- [clearcache]: will empty all the caches defined by the module [Ocsigen_base.Cache]
+
+
+{3 [<extconf>] : Splitting the configuration file}
+
+
+If your configuration is complex, it is recommended to split the configuration file into several files. The following command will include all external configuration files matching [*.conf] from this directory (in alphabetical order):
+
+
+
+{v
+<extconf dir="..."/>
+v}
+{2 Loading extensions and libraries}
+
+{3 [<extension>] : Loading extensions and libraries}
+
+
+Ocsigenserver does not do anything without some extensions loaded. For example, you need the extension staticmod for serving static pages. Extensions are loaded dynamically when launching the server. Specify the extensions and libraries you want using the tag <extension>.
+
+
+
+Warning: The order in which extensions are loaded is usually not significant (from 0.99.4) (but if you have dependencies between the modules). Extensions will try to handle requests in the order in which the options are written inside [<host>].
+
+
+
+If you want to run a Web site with Eliom, you probably need the extensions Staticmod and Eliom, the first one to generate static pages, the second one for dynamic pages.
+
+
+
+If you don't have any extension, no page will be generated.
+
+
+
+Extensions will not be reloaded if you ask the server to reread the configuration file. And they will be loaded only once, even if
+you have several times the same extension. For example if you are using [<extconf>] to configure several websites in several configuration files, you can put all the dependencies in each file.
+
+
+
+Some extensions take parameters between [<extension>] and [</extension>]
+
+
+
+Example of use:
+
+{v
+<extension module="/opt/godi/lib/ocaml/site-lib/ocsigenserver/staticmod.cma"/>
+v}
+
+(From version 1.0) Extensions can also be loaded using Findlib. If you specify a package which has dependencies, these dependencies will also be loaded, without parameters. Dependencies are always loaded only once, so you can safely load several extensions which have a shared dependency.
+
+
+
+If you don't want to clutter your installation with a lot of Ocsigen-specific packages, you can put them outside the default search path (for example, something below [/usr/local/lib/ocsigenserver]), and extend the search path in the configuration file. Here, "search path" has the same semantics as in Findlib. For example, you might have the following line in your configuration file if you compiled and installed Ocsigenserver on your own:
+
+
+
+{v
+<findlib path="/usr/local/lib/ocsigenserver/METAS"/>
+v}
+
+Extensions shipped with Ocsigen Server are available as subpackages of [ocsigenserver.ext] (this package is in an extended search path). For example:
+
+
+
+{v
+<extension findlib-package="ocsigenserver.ext.deflatemod">
+v}
+
+This will load deflatemod, and its dependency camlzip (if not already loaded).
+
+
+{3 [<require>] : Loading libraries}
+
+
+From version 1.0, [<require>] is a synonymous for [<extension>].
+
+
+{3 [<library>] : Loading libraries}
+
+
+If you want to load other OCaml libraries for your extensions or Website, use [<extension>] if you do not want them to be reloaded each time the configuration file is reread, or [<library>] if you need them to be reloaded every time. Extensions like CGImod or Staticmod or Eliom can not be loaded with [<library>]. Use [<library>] only for the modules you want to be able to reload without shutting down the server.
+
+
+
+Libraries may take parameters between [<library>] and [</library>].
+
+
+
+Example of use:
+
+
+
+{v
+<library module="/opt/godi/lib/ocaml/site-lib/mysite/mylib.cma"/>
+v}
+
+As in [<extension>], you can also use [findlib-package=] instead of [module=]. However, remember that dependencies will always be loaded only once (only the last file of the package itself may be reloaded several times).
+
+
+{2 Virtual host and site configuration}
+
+{3 [<host>] : Virtual host setting}
+
+
+It is possible to have several virtual hosts on the same server. For example if your server has two host names, you may want to serve different Web sites for each of them. Note that this feature is based on the [Host:] HTTP header, which is not mandatory in HTTP/1.0.
+
+
+The attribute [defaulthostname] is just an information about the hostname, that can be used for example by services to create absolute links. If you want to create virtual hosts for several domain names, use the [hostfilter] attribute to filter on the [Host] HTTP header. You may specify several hostnames, and the optional [hostfilter] field may contain '*' (wildcard). Example:
+
+
+{v
+<host defaulthostname="www.mysite.com" hostfilter="www.mysite.com *.org" charset="utf-8"> ... </host>
+v}
+
+The [charset] attribute is the default charset for your pages. All attributes are optional, but we recommend to set at least [defaulthostname].
+
+
+
+If you do not want to send any charset, explicitely: [charset=""]. In that case, browsers usually use html meta-data (when present).
+
+
+
+{e Warning:} Before version 1.2.0, [hostfilter] was called: [name] (or [aliases]).
+
+
+
+It is also possible to set the default ports for http and https, and default protocol using [defaulthttpport], [defaulthttpsport] and [defaultprotocol=]. These arguments may be used by extensions (like Eliom) if they need to create absolute links. Example:
+
+
+
+{v
+<host defaulthostname="www.mywebsite.org" hostfilter="*.org" defaulthttpport="8080" defaulthttpsport="4433" defaultprotocol="https"> ... </host>
+v}
+
+Inside [<host>], write the configuration for your main (root) site. These options depend on the extensions loaded. See the documentation about the extensions to know what to put here. It is also possible to define here several subsites, using [<site>] (see below).
+
+
+{3 [<site>] : Configuring sub-sites}
+
+
+In each virtual host, it is possible to define several sub-sites (in sub-paths) between [<site>] and [</site>]. [<site>] has an attribute [dir] to set the home directory for the site. You can also set the default charset for the site using the [charset] attribute. The options between [<site>] and [</site>] are exactly the same as those you can can put between [<host>] and [</host>]. They depend on the extensions you loaded. It is also possible to define sub-sites inside sub-sites.
+
+Example of use:
+{v
+<site path="mysite"> ... </site>
+v}
+
+{2 Reloading the configuration file}
+
+To reload the modules of the configuration file without stoping the server, write the command [reload] in the server's command pipe (usually [/var/run/ocsigenserver_command]. For example:
+
+{v
+echo reload > /var/run/ocsigenserver_command
+v}
+
+Form version 1.3, it is possible to give the name of the configuration file as parameter:
+
+{v
+echo reload /etc/ocsigenserver/ocsigenserver.conf.2 > /var/run/ocsigenserver_command
+v}
+
+Most distributions have a special command to do that automatically
+(for the default configuration file), usually:
+{v
+/etc/init.d/ocsigenserver reload
+v}
+
+The configuration file will be reloaded, and the changes will be taken into account if possible. For example it is not possible to change the port numbers without stoping the server for now. Extensions and libraries loaded using [<extension>] will not be reloaded.
+
+
+{2 Graceful shutdown {e (From version 1.3)}}
+
+To end the server cleanly, use the [shutdown] command, for example:
+
+{v
+echo shutdown > /var/run/ocsigenserver_command
+v}
+
+No new connection will be accepted, but all current requests will be terminated (with a timeout). Then the server process will end.
+
+You can specify the timeout as parameter (in second):
+
+{v
+echo shutdown 10 > /var/run/ocsigenserver_command
+v}
+
+It means that the server process will end after at most 10 seconds, even if some connexions are still alive. If you do not want any timeout, do:
+
+{v
+echo shutdown notimeout > /var/run/ocsigenserver_command
+v}
+
+In that case, the server will wait for all the connections to terminate, even if it takes a lot of time.
+
+The default timeout value can be set in the configuration file (see [shutdowntimeout] option above).

--- a/doc/cors.mld
+++ b/doc/cors.mld
@@ -1,0 +1,73 @@
+{0 The CORS extension}
+{e Cross-Origin Resource Sharing}
+
+This extension is used to allow other servers to serve pages
+requesting data on that one using XmlHttpRequest. It adds headers to
+the server response and handle preflight OPTIONS requests to indicate
+if some client side code has the right to access resources.
+
+See the {{:http://www.w3.org/TR/cors/}CORS specifications} for more
+informations.
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.cors],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+{v
+<extension findlib-package="ocsigenserver.ext.cors"/>
+v}
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Cors}.
+
+{1 config}
+
+The extension is activated by the [<cors/>] tag.
+
+The extension must be used after the extension serving the content (like eliom or staticmod) since it adds headers to already answered requests.
+
+The attributes of the cors tag are:
+
+- [max_age]: this is a integer telling the browser how long the
+  preflight information are valid: it prevents doing the OPTIONS
+  requests. This option adds the [Access-Control-Max-Age] header.
+
+- [credentials]: Adds the [Access-Control-Allow-Credentials]
+  header to the preflight request.
+
+- [exposed_headers]: This is a comma separated list of header
+  names. This is the list of user defined headers accessible from the
+  client. it Adds the [Access-Control-Expose-Headers] header.
+
+- [methods]: This is a comma separated list of method names. If
+  there is a requested method header in the preflight request, it adds
+  the [Access-Control-Allow-Methods] header if it match, otherwise
+  there is no cors header added.
+
+Note that the extension should be used with {{!page-"accesscontrol"}accesscontrol} to limit the application having access to the resources. This is done by checking the "origin" header.
+
+{1 Examples}
+
+- minimal configuration allowing all requests with no credentials.
+{v
+<cors/>
+v}
+
+- A configuration allowing access to an eliom application at path "eliom_site", from localhost:8081
+{v
+<if>
+  <and>
+    <header name="origin" regexp="http://localhost:8081"/>
+    <path regexp="eliom_site" />
+  </and>
+  <then>
+    <cors max_age="86400"
+          credentials="true"
+          methods="POST,GET,HEAD"
+          exposed_headers="
+            x-eliom-application,
+            x-eliom-location,
+            x-eliom-set-process-cookies"/>
+  </then>
+</if>
+v}

--- a/doc/deflatemod.mld
+++ b/doc/deflatemod.mld
@@ -1,0 +1,115 @@
+{0 Deflatemod}
+
+
+
+{1 Usage}
+
+{2 What is deflatemod?}
+
+Deflatemod is a module for Ocsigen that allows you to
+deflate content, using HTTP/1.1 mechanism. It supports gzip as well as
+deflate.
+
+{2 What do I need to use deflatemod?}
+
+You need the camlzip library by Xavier Leroy and a working Ocsigen
+installation.
+
+{2 How do I use deflatemod?}
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.deflatemod],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+{v
+<extension findlib-package="ocsigenserver.ext.deflatemod" />
+v}
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Deflatemod}.
+
+
+{2 How do I configure deflatemod?}
+
+Again, the options are in ocsigen.conf. You can set a few options globally, in the extension tag:
+
+- the compress level: from 0 (no compression) to 9. The higher, the
+  better compression rate you achieve. Conversely, the lower, the faster
+  it is. Default is 6.
+- the buffer size: default is 1024. You shouldn't need to change this
+  one, but you can still try a few other values (any feedback welcomed).
+
+For example:
+
+{v
+<extension module="/home/gabriel/ocsigen/extensions/deflatemod.cmo">
+<compress level="6" />
+<buffer size="1024" />
+</extension>
+v}
+
+Next, you '''have to''' specify which pages you whish to deflate, in which host/site (otherwise, deflatemod won't compress anything). See next question to do that.
+
+{2 I want to deflate only some files. Is it possible?}
+
+To some extent, yes. You can '''exclude''' some files and deflate every other, according to their mime-type or extension (''ie.'' the end of the '''url''' in fact, not really the file name on the disk).
+
+Here is an example:
+
+{v
+<host>
+<site>
+<!-- ... -->
+</site>
+
+<deflate compress="allbut">
+<!-- deflate everything but *.tar.gz files and image/* files -->
+    <extension>.tar.gz</extension>
+    <type>image/*</type>
+</deflate>
+</host>
+v}
+
+As you can see, you must put the <deflate> tag at the very end of the <host> element. Indeed, Ocsigen deals with extensions sequentially, so if you put <site> or other elements '''after''' <deflatemod>, they won't be compressed.
+
+Conversely, you can choose to deflate '''only''' some files, based
+on their mime-types or extension:
+
+{v
+<host>
+<site>
+<!-- ... -->
+</site>
+
+<deflate compress="only">
+<!-- deflate only text/html files -->
+    <type>text/html</type>
+</deflate>
+</host>
+v}
+
+
+Warning: you can use only one contenttype tag! So you must choose,
+either the "only" or the "allbut" way.
+
+Limitations: you cannot filter by directory or by filename extension (remember extension is the url's extension). If you really need it, please fill a bug report or send a patch.
+
+{1 Technical questions}
+
+{2 How can I choose the content-encoding (gzip or deflate)?}
+
+You can't. Deflatemod follows the RFC and chooses automatically the
+right encoding, based upon Accept-encoding header sent by the client.
+
+{2 Does deflatemod support transfert-encoding?}
+
+No, it  doesn't. Content-encoding is definitely a better solution,
+providing end to end compression at the content-level.
+
+{2 How does deflatemod deal with the content-length header?}
+
+As it cannot compute the new content-length, deflatemod uses
+chunked-encoding. This is the recommended way to go.
+
+
+{e Page written by Gabriel Kerneis}

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,4 @@
+; Manual and API landing pages, compiled in place by `dune build @doc`.
+; index.mld is the package landing page; the other .mld files are the manual.
+(documentation
+ (package ocsigenserver))

--- a/doc/eliom.mld
+++ b/doc/eliom.mld
@@ -1,0 +1,5 @@
+{0 Eliom}
+
+{e Eliom} is a powerful framework for programming Web applications in OCaml.
+
+See the full documentation {{:../eliom/}here}.

--- a/doc/extend.mld
+++ b/doc/extend.mld
@@ -1,0 +1,58 @@
+
+{0 Writing an extension for Ocsigen server}
+
+This page describes how to extend Ocsigen's server. This can be used to create new ways to generate pages (like Apache modules), to filter and change the requests (for example, rewriting of URLS), to extend the syntax of the configuration file.
+
+{2 Filtering the requests or writing a module to generate pages}
+
+You can take as example the files [staticmod.ml] or [accesscontrol.ml] from Ocsigen Server's distribution.
+
+The type of request is [Ocsigen.Extensions.request_info]
+(have a look at it in the interface of module {!Ocsigen.Extensions}).
+
+Each extensions loaded in the configuration file tries to handle the request and returns something of type [Extensions.answer]. If the page is not found by the extension ([Ext_not_found]), the following one will try to handle the request. If the page is found, the answer is [Ext_found r].
+An extension can also modify the request before giving it to the next one
+(answer [Ext_continue_with of Extensions.request_info]), etc.
+
+
+{2 Filtering the outputs}
+It is also possible to create extensions that will filter the output of the server
+(for example to compress it). It is very similar to the previous one.
+Have a look at the file [deflatemod.ml] for an example.
+
+{2 Extending the configuration file}
+
+{3 Extending the configuration file for an extension}
+
+ The parsing of Ocsigen's configuration file is using a very basic xml parser (package [xml-light]). The function to be registered by the [Extensions.register_extension] function takes two parameters: the path of the web site and the xml subtree.
+
+{v
+let parse_config path = function
+    Xml.Element ("tag", attr, content) -> ...
+      (* Do what you want here *)
+  | Xml.Element _ ->
+      raise (Extensions.Bad_config_tag_for_extension t)
+  | _ -> raise (Extensions.Error_in_config_file "(my extension)")
+v}
+
+The module [Parseconfig] defines functions to parse strings or sizes (in bytes, GB etc).
+
+{3 Giving parameters to an extension}
+
+Extensions may take parameters in the configuration file. During the loading of the extension, the function [Extensions.get_config ()] returns the xml tree between [<extension>] and [</extension>] (or [<library>] and [</library>]). Write a parser for that tree.
+
+{2 Catching the request before it is fully read}
+
+For some extensions of the Web server, it is necessary to catch the request before it has been fully read (especially before the body of the request has been read). For example it is the case if you want to write a (reverse) proxy.
+
+{2 Adding new commands for the server}
+
+If you want to add your own commands for the server command pipe, do something like:
+
+{v
+let () =
+  Ocsigen.Extensions.register_command_function ~prefix:"yourextensionname"
+    (fun s c -> match c with
+       | ["mycommand"] -> ...
+       | _ -> raise Ocsigen.Extensions.Unknown_command)
+v}

--- a/doc/extendconfiguration.mld
+++ b/doc/extendconfiguration.mld
@@ -1,0 +1,128 @@
+
+{0 Extendconfiguration}
+
+Extendconfiguration allows to configure some options of the server inside a [<host>] tag. (This extension is available starting from Ocsigen ≥ 1.2)
+
+{1 Loading the extension}
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.extendconfiguration],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+
+{v
+<extension findlib-package="ocsigenserver.ext.extendconfiguration"/>
+v}
+
+{1 Options}
+
+This section describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Extendconfiguration}.
+
+{2 Following symlinks}
+
+For extensions that access files on the filesystem ({{!page-"staticmod"}staticmod},...), you can decide whether symlinks should be followed or not, using the tag
+
+{v
+<followsymlinks value="VAL" />
+v}
+
+where [VAL] can be:
+- [never] entirely disallows following symlinks.
+- [always] always follows symlinks (more efficient). Note that this setting is not permitted in userconf files
+- [ownermatch] symlinks are followed only if the owner of the symlink and of the target coincide. (Default value)
+
+Notice that staticmod partially overrides this setting when it is not used in a userconf file. When used with the syntax [<static dir="dir" />], the checks start only after the directory [dir]. In regexp mode, the checks only start after the value given by the [root] attribute. See the documentation of {{!page-"staticmod"}staticmod} for details.
+
+{2 Hiding or forbidding local files}
+
+Again for extensions that send local files, you can selectively disallow sending some files. The syntax is as such:
+{v
+<hidefile>
+  <extension ext="php" />
+  <extension ext="cgi" />
+  <file file=".htaccess" />
+  <regexp regexp=".*hidden_file.*" /> <!-- End the regexp with $ to match the full file name -->
+</hidefile>
+v}
+
+Using the tag [hidefile] results in 404 error codes. To have 403 errors, use [forbidfile] instead.
+
+{2 Index of directories}
+
+When the user requests access to a directory of the filesystem, Ocsigen can automatically try to find an index file. This is done through the following option
+
+{v
+<defaultindex>
+  <index>index1</index>
+  <index>index2</index>
+</defaultindex>
+v}
+
+Ocsigen serves the first file (according to the order given by the index tags) that exists.
+
+{2 List the content of directories}
+
+If you want to list the content of a directory that does not contain an index file, use the tag
+
+{v
+<listdirs value="true" />
+v}
+
+You can also deactivate this option with [value="false"] instead.
+
+{2 Charset}
+
+The charset of the text files that are sent by the server can be set using the tag
+
+{v
+<charset default="utf-8">
+  <extension ext='txt' value="iso8859-15" />
+  <file file="bla.text" value="iso8859-15" />
+  <regexp regexp=".*text.*"  value="iso8859-15" />
+</charset>
+v}
+
+This sets the default charset for text files to [utf8], while files whose extension
+are [txt], or that are named [bla.text], or whose name contains [text] are sent as
+[iso8859-15].
+
+Multiple extension tags can be specified. Both the default attribute and extension tags are optional. Extension tags are cumulative between the various sites.
+
+{2 Content-type}
+
+The content-type for the files sent by the server can be specified using the tag
+
+{v
+<contenttype default="application/octet-stream">
+  <extension ext='txt' value="text/plain" />
+  <file file="bla.text" value="text/plain" />
+  <regexp regexp=".*text.*"  value="text/plain" />
+</contenttype>
+v}
+
+The options are similar to the ones for the [charset] tag.
+
+
+{2:upload File uploading}
+
+{e From Ocsigen ≥ 1.3}
+
+You can specify the directory in which the files stored in POST requests are uploaded, as well
+as the maximum size for these files. The two options are named [uploaddir] and [maxuploadfilesize]:
+{v
+<uploaddir>/tmp</uploaddir>
+<maxuploadfilesize>1MB</maxuploadfilesize>
+v}
+The arguments are the same as for the global corresponding options ; see the {{!page-"config".upload}configuration} page for details. In order to disallow uploading for a specific
+host or site, use an empty path: [<uploaddir></uploaddir>].
+
+{e Warning}
+
+POST arguments (including sent files) are read once and for all, by the first extension that attempts to decode the POST parameters. This means that the POST-uploaded files are stored {e according to the settings local to this first extension}. Changing the [uploaddir] and [maxuploadfilesize] options later will have no effect; plan accordingly when you write your [ocsigen.conf] file. Currently the only extension supplied
+with Ocsigen that reads POST data is Eliom.
+
+
+{1 Visibility}
+
+The options above are visible until the end of the <site> tag they are part of.

--- a/doc/launching.mld
+++ b/doc/launching.mld
@@ -1,0 +1,41 @@
+
+{0 Launching the server}
+
+
+To run the server, use the command [ocsigenserver]. It has the
+following options:
+
+{v
+  -c, --config
+         Alternate configuration file.
+
+  -d, --daemon
+         Daemon mode (detach the process).
+	 This is the default when there are more than 1 process.
+
+  -help, --help
+         Show summary of options.
+
+  -p, --pidfile
+         Specify a file where to write the PIDs of the servers.
+
+  -s, --silent
+         Silent mode (error messages go in errors.log only).
+
+  -v, --verbose
+         Verbose mode.
+
+  -vv, --veryverbose
+         Very verbose mode (info).
+
+  -vvv
+         Extremely verbose mode (debug).
+
+  --version
+         Show version of program.
+v}
+
+
+
+
+

--- a/doc/outputfilter.mld
+++ b/doc/outputfilter.mld
@@ -1,0 +1,52 @@
+{0 Outputfilter}
+
+Outputfilter allows to filter the output and rewrite some part of it (for example headers) before sending it to the client. It is in beta version. Submit your bugs, feature wishes (or any enhancement/mistake in the documentation) {{:https://github.com/ocsigen/ocsigenserver}here}.
+
+For now it only allows to change or add headers, or to change the HTTP code.
+
+{1 Configuration}
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.outputfilter],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+{v
+<extension findlib-package="ocsigenserver.ext.outputfilter"/>
+v}
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Outputfilter}.
+
+
+{2 Rewrite headers}
+
+When you want to rewrite one header (after having generated a page), do something like:
+{v
+<outputfilter header="location" regexp="http://my.newaddress.org/(.*)" dest="http://my.publicaddress.org/\1"/>
+v}
+Here we rewrite the content of the header location (this line is useful when you are using the reverse proxy).
+
+{2 Add headers}
+
+When you want to add a header (after having generated a page), do something like:
+{v
+<outputfilter header="X-Frame-Options" dest="SAMEORIGIN" replace="true"/>
+v}
+
+This will add the header "X-Frame-Options" with content "SAMEORIGIN"
+to the generated page. The replace attribute is optionnal.
+- If replace is "true", the previous headers are replaced.
+- If replace is "false", it will be added even if there was a header with the same name.
+- If not set, it will be added only if there was no header with the same name.
+(This line is usefull when you want to avoid clickjacking)
+
+{2 Change HTTP code}
+
+The syntax to change the HTTP code is:
+
+{v
+<sethttpcode code=... />
+v}
+
+where the value of the code attribute is a valid HTTP code
+(404 or 200 for example).

--- a/doc/quickstart.mld
+++ b/doc/quickstart.mld
@@ -1,0 +1,143 @@
+
+{0 Ocsigen Server}
+  
+
+
+Ocsigen Server is a powerful and modular generic purpose Web Server.
+It supports static files, redirections, reverse proxy, CORS,
+user pages with local configuration, page compression,
+authentication, etc.
+
+Ocsigen Server can be used:
+- as an executable: it reads its configuration from a file and dynamically loads
+  the extensions and libraries you need for your sites, 
+- or as a library: build your own executable and statically link your the
+  modules you need for your pages.
+
+It is written in OCaml and uses the
+{{:https://github.com/mirage/ocaml-cohttp}Cohttp} library.
+
+{1 Installation}
+
+The easier way to install Ocsigenserver is to use the [opam] package 
+manager. Ocsigen Server is also available in Linux distributions.
+
+{1 Using Ocsigen Server as an executable}
+
+Create your configuration file. You can take this one as an example:
+{v
+<ocsigen>
+  <server>
+    <port>8080</port>
+
+    <logdir>local/var/log/mysite</logdir>
+    <datadir>local/var/data/mysite</datadir>
+    <charset>utf-8</charset>
+
+    <commandpipe>local/var/run/mysite-cmd</commandpipe>
+    <extension findlib-package="ocsigenserver.ext.staticmod"/>
+    <host hostfilter="*">
+      <static dir="local/var/www/mysite/" />
+    </host>
+  </server>
+</ocsigen>
+v}
+Update the paths to match your configuration and create the missing directories.
+Then run:
+{v
+ocsigenserver -c <name of your configuration file>
+v}
+
+{2 Personalising your configuration}
+
+Have a look at the page {{!page-"config"}Configuration} to
+learn how to personalise the configuration file and adapt it to your
+needs.
+
+{1 Using Ocsigen Server as a library}
+
+If you want to include a Web Server in your OCaml app,
+add library [ocsigenserver] and the extensions you need 
+(here [ocsigenserver.ext.staticmod]) in your Dune file:
+{v
+(executable
+ (public_name myapp)
+ (name main)
+ (libraries
+  ocsigenserver
+  ocsigenserver.ext.staticmod))
+v}
+Call function {!Ocsigen.Server.start} like this to run the server:
+{@ocaml[
+let _ =
+  Ocsigen.Server.start
+    [ Ocsigen.Server.host [Staticmod.run ~dir:"local/var/www/mysite/" ()]]
+]}
+
+The server runs on port 8080 by default.
+Customise this using optional parameters of function
+{!Ocsigen.Server.start}
+
+{1 Extensions}
+
+Depending on the features you need, you can extend the server by loading
+some modules.
+
+The extensions provided are:
+
+;{{!page-"staticmod"}Staticmod}
+:for serving static pages,
+;{{!page-"accesscontrol"}Accesscontrol}
+:if you need to restrict the access to the sites,
+;{{!page-"eliom"}Eliom}
+:if you want to use dynamic Web and mobile applications written in OCaml with Eliom,
+;{{!page-"revproxy"}Revproxy}
+:if you want to redirect some requests to another Web server,.
+;{{!page-"redirectmod"}Redirectmod}
+:if you want to define some HTTP redirections,
+;{{!page-"deflatemod"}Deflatemod}
+:if you want to compress the content before sending your pages,
+;{{!page-"outputfilter"}Outputfilter}
+:allows to change the header of the HTTP response,
+;{{!page-"rewritemod"}Rewritemod}
+:allows to rewrite the request before continuing,
+;{{!page-"extendconfiguration"}Extendconfiguration}
+:adds many useful configuration options,
+;{{!page-"authbasic"}Authbasic}
+:for basic HTTP authentication,
+;{{!page-"cors"}CORS}
+:for settings CORS options,
+;{{!page-"userconf"}Userconf}
+:for allowing local users to have personal pages,
+
+If you are using a configuration, file, use tag 
+[<extension/>] to load an exetnsion (see examples in the
+manual of each extension). Most extension have configuration
+options, and define new tags for the configuration file.
+
+If you are building a static executable, load the extensions
+as any library from your Dune file. Have a look at the API
+documentation of each documentation to see the functions
+it defines and the configuration options.
+
+{1 Running on port 80 or 443}
+It is not recommended to run a Web server as root.
+If you want to use priviledged ports (port numbers less than 1024), like 80 or
+443, you can add the capability to ocsigenserver with:
+{v
+setcap 'cap_net_bind_service=+ep' <path to the server executable>
+v}
+
+{1 If something goes wrong}
+
+If something goes wrong, first have a look in the logs to see if there
+is an error message. The directory of logs is set in the configuration
+file or through option [?logdir] of function
+{!Ocsigen.Server.start}
+([$OPAM_SWITCH_PREFIX/lib/ocsigenserver/var/log/ocsigenserver] by 
+default).
+
+If you cannot solve your problem, if you find a bug,
+a mistake in the documentation (even a small one),
+or if you want to make a suggestion,
+{{:https://github.com/ocsigen/ocsigenserver}open an issue on Github}.

--- a/doc/redirectmod.mld
+++ b/doc/redirectmod.mld
@@ -1,0 +1,45 @@
+{0 Redirectmod}
+
+Redirectmod is a module allowing to define HTTP redirections from Ocsigen's configuration file. Submit your bugs and feature wishes (or any enhancement/mistake in the documentation) {{:https://github.com/ocsigen/ocsigenserver}here}.
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.redirectmod],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+{v
+<extension findlib-package="ocsigenserver.ext.redirectmod"/>
+v}
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Redirectmod}.
+
+
+
+Then configure your hosts as in these examples:
+{v
+<redirect suburl="(.*)" dest="http://my.newaddress.org/\1"/>
+<redirect suburl="dir/(.*)\.html" dest="http://my.newaddress.org/\1.php"/>
+<redirect fullurl="http://(.*).myserver.org/(.*)" dest="http://\1.mynewserver.org/\2"/>
+v}
+The syntax of regular expression is PCRE's one.
+
+According to the RFC of the HTTP protocol, dest must be an absolute URL. By default, the redirection is permanent. For temporary redirection, use:
+{v
+<redirect temporary="temporary" suburl="(.*)" dest="http://www.plopplopplop.com/\1"/>
+v}
+
+
+Other example:
+redirect [https://foobar.org/aaa] (and [https://foobar.net/aaa] etc.)
+to [https://www.foobar.org/aaa] (and http to https):
+
+{v
+    <host hostfilter="foobar.org www.foobar.net foobar.net"
+          defaulthostname="www.foobar.org" defaulthttpport="80" defaulthttpsport="443">
+      <redirect suburl="(.*)" dest="https://www.foobar.org/\1"/>
+    </host>
+    <host hostfilter="www.foobar.org"
+          defaulthostname="www.foobar.org" defaulthttpport="80" defaulthttpsport="443">
+       ...
+    </host>
+v}

--- a/doc/revproxy.mld
+++ b/doc/revproxy.mld
@@ -1,0 +1,57 @@
+{0 Revproxy}
+
+Revproxy is a reverse proxy for Ocsigen.
+
+This module allows to transmit some requests to another Web server using the HTTP or HTTPS protocol. For example if you want to use Ocsigen together with another Web server (Apache, Tomcat, etc. or even another Ocsigen).
+
+{2 Configuration}
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.revproxy],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+{v
+<extension findlib-package="ocsigenserver.ext.revproxy"/>
+v}
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Revproxy}.
+
+Here are some examples of configuration file options:
+
+{v
+<revproxy suburl="(.*)" dest="http://my.newaddress.org:8080/\1"/>
+<revproxy suburl="dir/(.*)\.html" dest="https://my.newaddress.org/\1.php"/>
+<revproxy fullurl="http://(.*).mydomain.org:(80|8080)/(.*)" dest="http://\1.my.newdomain.org:\2/\3"/>
+v}
+
+regexp is a regular expression using PERL syntax (PCRE). The destination URL is built from dest, where \i corresponds to the i-th part between parenthesis of the regular expression (was $i in older versions).
+
+Add the attribute [keephost="keephost"] if you want to send the original [Host] header to the distant server.
+Otherwise, it will be computed from [dest].
+
+Add the attribute [nopipeline="nopipeline"] if for some reason you don't want to pipeline reverse proxy's requests. With that option, the reverse proxy will open a new connection for all requests, instead of trying to reuse connections. You probably don't need that, but if you do, please contact us to tell us what is the problem. Thank you!
+
+You probably also need to rewrite locations in the output (if the server is doing redirections). For example:
+
+{v
+<outputfilter header="location" regexp="http://my.newaddress.org/(.*)" dest="http://my.publicaddress.org/\1"/>
+v}
+
+Note that if you are using ocsigen behind a reverse proxy handling X-Forward-For and X-Forward-Proto headers ( like the revproxy module ), you should allow ocsigen to use those informations, using accesscontrol extension
+
+{v
+<if>
+	<ip value="ip of the proxy"/>
+	<then>
+	 	<allow-forward-for/>
+    		<allow-forward-proto/>
+	</then>
+</if>
+v}
+
+{2 Technical details}
+
+- The reverse proxy does no caching for now.
+- The reverse proxy does pipeline the requests for server it trusts for pipelining. But current trusting criteria are probably too strong. They will probably evolve soon.
+

--- a/doc/rewritemod.mld
+++ b/doc/rewritemod.mld
@@ -1,0 +1,27 @@
+{0 Rewritemod}
+
+Rewritemod allows to rewrite the requests.It is available from Ocsigen version 1.2. It is really basic for now, but for most uses you don't need it, as staticmod and others already have sophisticated configuration features. It is in beta version. Submit your bugs and feature wishes {{:https://github.com/ocsigen/ocsigenserver}here}.
+
+To use that extension, load OCamlfind package [ocsigenserver.ext.rewritemod],
+either from your Dune file (if you are using static linking), or
+from the configuration file:
+{v
+<extension findlib-package="ocsigenserver.ext.rewritemod"/>
+v}
+
+This page describes the configuration file options. If you are building a statically
+linked executable without configuration file, use the corresponding functions from
+module {!Rewritemod}.
+
+
+Configure your hosts from the config file as in this example:
+{v
+<rewrite regexp="(.*)" url="toto/\1"/>
+v}
+The syntax of regular expression is PCRE's one.
+
+By default, the modified request will restart from the beginning, as if
+it were a new request.
+If you do not want to restart, but just continue to the next options
+in the configuration file, add attribute [continue="continue"].
+

--- a/doc/staticlink.mld
+++ b/doc/staticlink.mld
@@ -1,0 +1,213 @@
+{0 Using Ocsigen Server as a library}
+
+{1 Creating and running a statically linked executable}
+
+Instead of using a configuration file, you can use Ocsigen Server as a library
+for your OCaml program.
+
+Call function {!Ocsigen.Server.start} like this to run the server:
+{@ocaml[
+let _ =
+  Ocsigen.Server.start
+    [ Ocsigen.Server.host [Staticmod.run ~dir:"local/var/www/mysite/" ()]]
+]}
+
+Have a look at the API documentation for {!Ocsigen.Server.start}
+to see how to provide configuration options.
+
+As with the configuration file, you can define several virtual hosts,
+for example for different hostnames. See function 
+{!Ocsigen.Server.host} to configure them.
+
+Functions like {!Staticmod.run} are defined by extensions.
+
+The programming interface follows exactly the structure of the configuration file:
+Each request received by the server goes through all the instructions given
+in the list. These instructions can be:
+- either input filters that will modify the request
+  (for example {{:rewritemod}Rewritemod})
+- or page generation instructions (for example with {{:staticmod}Staticmod},
+  {{:eliom}Eliom} or {{:redirectmod}Redirectmod})
+- or output filters, that will modify the result (for example
+  {{:deflatemod}Deflatemod} or {{:cors}CORS}).
+
+Here is an example of a more complex configuration:
+{@ocaml[
+let _ =
+  Ocsigen.Server.start
+    ~ports:[`All, 8080]
+    ~command_pipe:"local/var/run/mysite-cmd"
+    ~logdir:"local/var/log/mysite"
+    ~datadir:"local/var/data/mysite"
+    ~default_charset:(Some "utf-8")
+    [ Ocsigen.Server.host
+        ~regexp:"mydomain.com"
+        [ Ocsigen.Server.site ["subsite"]
+            [ Accesscontrol.(
+                if_
+                  (and_
+                     [ ip "122.122.122.122"
+                     ; header ~name:"user-agent" ~regexp:".*FooBar.*"
+                     ; method_ `POST ])
+                  [forbidden] [])
+            ; Authbasic.run ~realm:"myrealm"
+                ~auth:(fun _u p -> Lwt.return (p = "toto"))
+                ()
+            ; Staticmod.run ~dir:"local/var/www/otherdir" () ]
+        ; Ocsigen.Server.site ["othersubsite"]
+            [ Revproxy.run
+                ~redirection:
+                  (Revproxy.create_redirection ~full_url:false ~regexp:"(.*)"
+                     ~keephost:true "http://localhost:8888/\\1")
+                () ]
+        ; Redirectmod.run
+            ~redirection:
+              (Redirectmod.create_redirection ~full_url:false ~regexp:"old(.*)"
+                 "new\\1")
+            ()
+        ; Staticmod.run ~dir:"local/var/www/staticdir" ()
+        ; Cors.run ~max_age:86400 ~credentials:true ~methods:[`POST; `GET; `HEAD]
+            ~exposed_headers:
+              [ "x-eliom-application"
+              ; "x-eliom-location"
+              ; "x-eliom-set-process-cookies"
+              ; "x-eliom-set-cookie-substitutes" ]
+            ()
+        ; Deflatemod.run
+            ~mode:
+              (`Only
+                [ `Type (Some "text", Some "html")
+                ; `Type (Some "text", Some "javascript")
+                ; `Type (Some "text", Some "css")
+                ; `Type (Some "application", Some "javascript")
+                ; `Type (Some "application", Some "x-javascript")
+                ; `Type (Some "application", Some "xhtml+xml")
+                ; `Type (Some "image", Some "svg+xml")
+                ; `Type (Some "application", Some "x-eliom") ])
+            () ] ]
+]}
+In this example, the server defines one virtual host for domain [mydomain.com].
+It will first check whether it is a request for directory [subsite/], and if yes, will reject the request
+with [403 Forbidden] if it is a POST request coming from user-agent [FooBar] at IP 122.122.122.122.
+If not, it will ask for a password before serving files from directory [local/var/www/otherdir].{%html:<br/>%}
+Then we define another subsite othersubsite for which the requests will be transfered to another Web server
+running locally on port 8888, then rewrite the answer location header accordingly.
+Then, if the page is still not generated, the server will send a redirection if URLs starts with “old”.
+Otherwise, it will try to serve files from directory [local/var/www/staticdir].
+If the page has still not been found, a [404 Not found] will be sent, otherwise, some CORS headers will
+be added, and the result will be compressed before being sent.
+
+Compile this example with the following dune file:
+{v
+(executable
+ (public_name myserver)
+ (name main)
+ (libraries
+  ocsigenserver
+  ocsigenserver.ext.staticmod
+  ocsigenserver.ext.authbasic
+  ocsigenserver.ext.extendconfiguration
+  ocsigenserver.ext.outputfilter
+  ocsigenserver.ext.cors
+  ocsigenserver.ext.accesscontrol
+  ocsigenserver.ext.deflatemod
+  ocsigenserver.ext.redirectmod
+  ocsigenserver.ext.revproxy
+ ))
+v}
+
+This program corresponds to the following configuration file:
+{v
+<ocsigen>
+  <server>
+    <port>8080</port>
+    <commandpipe>local/var/run/mysite-cmd</commandpipe>
+    <logdir>local/var/log/mysite</logdir>
+    <datadir>local/var/data/mysite</datadir>
+    <charset>utf-8</charset>
+    <debugmode/>
+    <extension findlib-package="ocsigenserver.ext.staticmod"/>
+    <extension findlib-package="ocsigenserver.ext.authbasic"/>
+    <extension findlib-package="ocsigenserver.ext.extendconfiguration"/>
+    <extension findlib-package="ocsigenserver.ext.outputfilter"/>
+    <extension findlib-package="ocsigenserver.ext.cors"/>
+    <extension findlib-package="ocsigenserver.ext.accesscontrol"/>
+    <extension findlib-package="ocsigenserver.ext.deflatemod"/>
+    <extension findlib-package="ocsigenserver.ext.redirectmod"/>
+    <extension findlib-package="ocsigenserver.ext.revproxy"/>
+    <host hostfilter="mydomain.com">
+      <site dir="subsite">
+        <if>
+          <and>
+            <ip value="122.122.122.122"/>
+            <header name="user-agent" regexp=".*FooBar.*"/>
+            <method value="POST"/>
+          </and>
+          <then>
+            <forbidden/>
+          </then>
+        </if>
+        <authbasic realm="myrealm">
+          <plain login="" password="toto"/>
+        </authbasic>
+        <static dir="local/var/www/otherdir"/>
+      </site>
+      <site dir="othersite">
+        <revproxy suburl="(.*)" keephost="true" dest="http://localhost:8888/otherdir/\\1"/>
+        <outputfilter header="location" regexp="http://localhost:8888/(.* )" dest="http://mydomain.com/\\1"/>
+      </site>
+      <redirect suburl="old(.*)" dest="http://mydomain.org/new\\1"/>
+      <static dir="local/var/www/staticdir"/>
+      <cors max_age="86400"
+       credentials="true"
+       methods="POST,GET,HEAD"
+       exposed_headers="x-eliom-application,x-eliom-location,x-eliom-set-process-cookies,x-eliom-set-cookie-substitutes"/>
+      <deflate compress="only">
+        <type>text/html</type>
+        <type>text/javascript</type>
+        <type>text/css</type>
+        <type>application/javascript</type>
+        <type>application/x-javascript</type>
+        <type>application/xhtml+xml</type>
+        <type>image/svg+xml</type>
+        <type>application/x-eliom</type>
+      </deflate>
+    </host>
+  </server>
+</ocsigen>
+v}
+
+{1 Experimental: Using a configuration file with a static executable}
+If you want to use the configuration file with a statically linked executable,
+call
+{v
+Ocsigen.Server.exec (Ocsigen.Parseconfig.parse_config ())
+v}
+to launch the server's main loop.
+
+Alternatively, you can link module [ocsigenserver.cmx]
+to set the default commandline option and launch the main loop.
+
+If you still want to use dynamic linking, add option [-linkall] while
+compiling, otherwise the compiler may remove some modules from packages
+[cma/cmxa].
+
+All statically linked extensions need to be initialized from the configuration 
+file. To do that, replace the lines like:
+{v
+<extension module="staticmod.cmxs" />
+v}
+or
+{v
+<extension findlib-package="ocsigenserver.ext.staticmod" />
+v}
+by
+{v
+<extension name="staticmod" />
+v}
+This will not load a new module, but merely initializes one which must have been
+linked statically. Thus it is possible to give configuration options to
+extensions as usual.
+
+This is an experimental feature.
+Let us know if you test it (for example by opening an issue on Github).

--- a/doc/staticmod.mld
+++ b/doc/staticmod.mld
@@ -1,0 +1,78 @@
+{0 Staticmod}
+Staticmod is a module allowing to serve static pages (files).
+
+{1 Using as a library}
+To use that extension as a library for your OCaml programs,
+load OCamlfind package [ocsigenserver.ext.staticmod],
+from your Dune file, and
+have a look at the {{!Staticmod}API documentation}.
+
+{1 Configuration file}
+{2 Basics}
+
+To use that extension with Ocsigen Server's configuration file,
+load the extension like this:
+{v
+<extension findlib-package="ocsigenserver.ext.staticmod"/>
+v}
+Then configure your hosts as in this example:
+{v
+<static dir="/path/to/the/local/directory" />
+v}
+Note that when running Ocsigenserver as a daemon, a relative path is
+interpreted starting at [/].
+
+{2 Rewriting URLs}
+
+You may also want to filter or rewrite URLs, as in this example, that allows user to have their home pages:
+{v
+<static regexp="~([^/]*)(.*)" dest="/home/\1/public_html\2"/>
+v}
+[regexp] is a regular expression using PERL syntax (PCRE).
+
+Actually, for user's pages, it is better to do:
+{v
+<static regexp="~([^/]*)(.*)" dest="$u(\1)/public_html\2"/>
+v}
+[$u(toto)] will be replaced by the home directory for user toto.
+
+You can also specify the option root as in
+{v
+<static regexp="~([^/]*)(.*)" dest="$u(\1)/public_html\2" root="$u(\1)/public_html"/>
+v}
+This will wave all symlinks checks above the directory [u(\1)/public_html]. This option is not permitted inside userconf files.
+
+{2 Catching HTTP errors}
+
+Here is an example on how to set a default error page for all 40x errors:
+{v
+<static code="40." regexp=".*" dest="/your/error/page.html"/>
+v}
+[code] is a regular expression (here matching 400, 401 etc.). [regexp] is optional (matches the URL path).
+
+Note that if you want to catch errors from all sites, you need to put this configuration in a separate <site path="">at the end of your configuration file.
+
+{2 Max-age and Expires}
+
+Here is an example on how to set up the [Cache-control: max-age]
+and [Expires] HTTP headers:
+
+{v
+<static dir="/path/to/the/local/directory" cache="2678400" />
+v}
+
+The [cache] argument is given in seconds. (1 month in the example)
+
+When the [cache] argument is [0] or [no], the
+[Cache-control: no-cache] header is sent.
+
+{2 Staticmod and userconf}
+
+(version 1.2.0 and greater)
+
+Staticmod is authorized inside userconf files, but all paths specified by dir or dest must be relative, and cannot contain "[/../]" or end by "[/..]". The relative paths are concatenated with the result of evaluating the attribute localpath of userconf.
+
+
+{2 Other options}
+
+See also module extendconfiguration for some options, like the ability to follow symlinks or to display directories. In particular, the old syntax [readable="readable"] is no longer available in staticmod (but can be simulated by the option [listdirs] of extendconfiguration).

--- a/doc/userconf.mld
+++ b/doc/userconf.mld
@@ -1,0 +1,30 @@
+{0 Userconf}
+Userconf allows users to have their own configuration files. It is in beta version, and requires some cooperation
+from other extensions to disallow unsafe options (for example, in version 1.2 it is not possible to have Eliom sites for users).
+
+{1 Configuration}
+
+To use this extension, first load it from the configuration file:
+
+{v
+<extension findlib-package="ocsigenserver.ext.userconf"/>
+v}
+
+Then, if you want to allow users to have their own configuration files, put in your hosts something like the lines
+below. (Unless you understand Userconf well, you probably just want to use those lines as is.)
+{v
+<redirect regexp="(https?://[^/]*)/~([^/]*)" dest="\1/~\2/" />
+<userconf regexp="~([^/]*)/(.*)" conf="$u(\1)/.ocsigen" prefix="~\1" url="\2" localpath="$u(\1)/public_html" />
+v}
+
+The configuration file specified in [conf] will be parsed for each request matching the regular expression
+[regexp]. Here, as in staticmod, [$u(toto)] is the Unix home directory of user [toto]. Extensions inside
+the user configuration file will behave as though executed in a [<site>] tag of root [prefix], while
+[url] is used to match the remainder of the url (the path [prefix/url] must be equal to [regexp]).
+Finally, the option [localpath] is used to specify the files the user is allowed to send: in userconf mode,
+all the paths used in {{!page-"staticmod"}Staticmod} must be relative, and are appended after the evaluation of
+[localpath].
+
+
+The syntax of user configuration files is usually the same as the one of the part between [<host>] and [</host>] in the main configuration file. However, the extensions can choose to disallow some options that are unsafe in user mode,
+or forbid user mode entirely. See their individual documentation for details.

--- a/src/extensions/accesscontrol.mli
+++ b/src/extensions/accesscontrol.mli
@@ -21,7 +21,7 @@
 (** Accesscontrol: Conditional access to some sites *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file, 
-+   have a look at the {% <<a_manual chapter="accesscontrol"|manual page>>%}.
++   have a look at the {{!page-"accesscontrol"}manual page}.
 +   If you are using Ocsigen Server as a library, use the interface described
 +   here. Each of these functions behaves exactly as its configuration file
     counterpart. 
@@ -32,7 +32,7 @@ This module belongs to ocamlfind package
    [ocsigenserver.ext.accesscontrol].
 *)
 
-(** Example of use (with {% <<a_manual chapter="redirectmod"|Redirectmod>>%}):
+(** Example of use (with {{!page-"redirectmod"}Redirectmod}):
 {[
 let _ =
   Ocsigen.Server.start

--- a/src/extensions/authbasic.mli
+++ b/src/extensions/authbasic.mli
@@ -21,7 +21,7 @@
 (** Authbasic: Basic HTTP authentication *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file,
-    have a look at the {% <<a_manual chapter="authbasic"|manual page>>%}.
+    have a look at the {{!page-"authbasic"}manual page}.
     If you are using Ocsigen Server as a library, use the interface described
     here. Each of these functions behaves exactly as its configuration file
     counterpart.

--- a/src/extensions/cors.mli
+++ b/src/extensions/cors.mli
@@ -1,7 +1,7 @@
 (** Cross-Origin Resource Sharing *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file, 
-    have a look at the {% <<a_manual chapter="cors"|manual page>>%}.
+    have a look at the {{!page-"cors"}manual page}.
     If you are using Ocsigen Server as a library, use the interface described
     here. Each of these functions behaves exactly as its configuration file
     counterpart.

--- a/src/extensions/deflatemod.mli
+++ b/src/extensions/deflatemod.mli
@@ -1,7 +1,7 @@
 (** Deflatemod: compress output data *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file, 
-+   have a look at the {% <<a_manual chapter="deflatemod"|manual page>>%}.
++   have a look at the {{!page-"deflatemod"}manual page}.
 +   If you are using Ocsigen Server as a library, use the interface described
 +   here. Each of these functions behaves exactly as its configuration file
     counterpart. 

--- a/src/extensions/extendconfiguration.mli
+++ b/src/extensions/extendconfiguration.mli
@@ -1,7 +1,7 @@
 (** Extendconfiguration: More configuration options for Ocsigen Server *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file,
-    have a look at the {% <<a_manual chapter="extendconfiguration"|manual page>>%}.
+    have a look at the {{!page-"extendconfiguration"}manual page}.
     If you are using Ocsigen Server as a library, use the interface described
     here. Each of these functions behaves exactly as its configuration file
     counterpart. 

--- a/src/extensions/outputfilter.mli
+++ b/src/extensions/outputfilter.mli
@@ -1,7 +1,7 @@
 (** Outputfilter: Rewrite some part of the output *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file,
-    have a look at the {% <<a_manual chapter="outputfilter"|manual page>>%}.
+    have a look at the {{!page-"outputfilter"}manual page}.
     If you are using Ocsigen Server as a library, use the interface described
     here. Each of these functions behaves exactly as its configuration file
     counterpart. 

--- a/src/extensions/redirectmod.mli
+++ b/src/extensions/redirectmod.mli
@@ -1,7 +1,7 @@
 (** Redirectmod: HTTP redirections *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file,
-    have a look at the {% <<a_manual chapter="redirectmod"|manual page>>%}.
+    have a look at the {{!page-"redirectmod"}manual page}.
     If you are using Ocsigen Server as a library, use the interface described
     here. Each of these functions behaves exactly as its configuration file
     counterpart.

--- a/src/extensions/revproxy.mli
+++ b/src/extensions/revproxy.mli
@@ -1,7 +1,7 @@
 (** Revproxy: Forward a request to another Web server *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file,
-    have a look at the {% <<a_manual chapter="revproxy"|manual page>>%}.
+    have a look at the {{!page-"revproxy"}manual page}.
     If you are using Ocsigen Server as a library, use the interface described
     here. Each of these functions behaves exactly as its configuration file
     counterpart.
@@ -15,7 +15,7 @@ This module belongs to ocamlfind package
 (** Example of use. Forward all requests to a given directory to the
 same directory of another server running locally on another port.
 We are using it in combination with
-{% <<a_manual chapter="outputfilter"|Outputfilter>>%} to rewrite redirections.
+{{!page-"outputfilter"}Outputfilter} to rewrite redirections.
 
 {[
 let _ =

--- a/src/extensions/rewritemod.mli
+++ b/src/extensions/rewritemod.mli
@@ -1,7 +1,7 @@
 (** Rewrite: Change the request *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file, 
-    have a look at the {% <<a_manual chapter="rewritemod"|manual page>>%}.
+    have a look at the {{!page-"rewritemod"}manual page}.
     If you are using Ocsigen Server as a library, use the interface described
     here. Each of these functions behaves exactly as its configuration file
     counterpart. 

--- a/src/extensions/staticmod.mli
+++ b/src/extensions/staticmod.mli
@@ -1,7 +1,7 @@
 (** Staticmod: serve static files *)
 
 (** If you want to use this extension with Ocsigen Server's configuration file, 
-   have a look at the {% <<a_manual chapter="staticmod"|manual page>>%}.
+   have a look at the {{!page-"staticmod"}manual page}.
    If you are using Ocsigen Server as a library, use the interface described
    here.
 *)
@@ -31,6 +31,6 @@ val run :
 (** Run static mod on a specific directory. 
     Call this if you want to run Ocsigen Server without configuration file.
     The optional parameter correspond to the options of the configuration
-    file described {% <<a_manual chapter="staticmod"|here>>%}.*)
+    file described {{!page-"staticmod"}here}.*)
 
 val section : Logs.src

--- a/src/server/Ocsigen/server.mli
+++ b/src/server/Ocsigen/server.mli
@@ -68,7 +68,7 @@ val start :
 (** Start the server with some instructions. Never returns.
     It takes as main parameter a list of virtual hosts (see {!host} below). 
 
-{% Options behave exactly like their <<a_manual chapter="config"|configuration file>>%}
+{% Options behave exactly like their {{!page-"config"}configuration file}%}
 counterparts.
 *)
 


### PR DESCRIPTION
**Draft for review** — part of the Ocsigen documentation rationalization (html_of_wiki/wikicreole → odoc, rendered by `wodoc`). This is the **dev** counterpart of #284 (which targets `master` / 7.0): it brings the same doc migration to the `modernize` branch (hierarchical module names, #282), which had no `.mld` yet.

Two commits:
- **`.mli` doc comments**: convert wikicreole `<<a_api>>` / `<<a_manual>>` references to native odoc references (`{!Ocsigen.Server…}`, `{{!page-"chapter"}}`), `{% … %}` unwrapped. References use modernize's hierarchical names (`Ocsigen.Server`, `Ocsigen.Extensions`, …).
- **Manual + API landing**: `doc/*.mld` generated from the dev manual sources (wikidoc `doc/dev/manual`, whose module names match modernize) with `wodoc convert --odoc-refs`; `doc/api.mld` curated to modernize's actual modules; `(documentation (package ocsigenserver))` stanza.

Builds cleanly (`dune build @doc` + wodoc assemble): 92 pages, manual + API landing **0 unresolved xref**. Remaining build warnings are doc-comment refs to dependencies (Lwt_stream, Ocsigen_http_frame) and the compat shims — out of scope. Procedure documented in the rationalization report (§11).