### PR TITLE
doc: use page references in staticlink.mld (not external-link syntax)

### DIFF
--- a/doc/staticlink.mld
+++ b/doc/staticlink.mld
@@ -25,11 +25,11 @@ The programming interface follows exactly the structure of the configuration fil
 Each request received by the server goes through all the instructions given
 in the list. These instructions can be:
 - either input filters that will modify the request
-  (for example {{:rewritemod}Rewritemod})
-- or page generation instructions (for example with {{:staticmod}Staticmod},
-  {{:eliom}Eliom} or {{:redirectmod}Redirectmod})
+  (for example {{!page-rewritemod}Rewritemod})
+- or page generation instructions (for example with {{!page-staticmod}Staticmod},
+  {{!page-eliom}Eliom} or {{!page-redirectmod}Redirectmod})
 - or output filters, that will modify the result (for example
-  {{:deflatemod}Deflatemod} or {{:cors}CORS}).
+  {{!page-deflatemod}Deflatemod} or {{!page-cors}CORS}).
 
 Here is an example of a more complex configuration:
 {@ocaml[


### PR DESCRIPTION
`doc/staticlink.mld` linked its sibling manual pages (rewritemod, staticmod, eliom, redirectmod, deflatemod, cors) with the **external-link** form `{{:name}label}`. odoc treats the target as a raw URL: it is not verified at build time and only resolves by accident of the deployed flat layout.

Switch them to proper **page references** `{{!page-name}label}` — odoc checks these (the build fails on a broken ref) and they survive layout changes. This matches the convention already used elsewhere in the manual (e.g. `{{!page-quickstart}manual}`).

Flagged by @Julow in review of #284 (which has since merged without the fix). The same change is applied to the `doc-mld` branch (#283).

All six target pages exist in `doc/`.