### PR TITLE
doc: add a home page (index.mld) for the ocaml.org documentation

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,48 @@
+@children_order quickstart launching config staticlink staticmod eliom extendconfiguration accesscontrol authbasic deflatemod redirectmod revproxy rewritemod outputfilter userconf cors extend api
+@short_title Ocsigen Server
+
+{0 Ocsigen Server}
+
+Ocsigen Server is a powerful and modular general-purpose Web server,
+written in OCaml. It supports static files, redirections, reverse proxy,
+CORS, user pages with local configuration, page compression,
+authentication, and more.
+
+It can be used:
+- as an executable: it reads its configuration from a file and dynamically
+  loads the extensions and libraries you need for your sites;
+- or as a library: build your own executable, statically linked with the
+  modules you need.
+
+Ocsigen Server is part of the {{:https://ocsigen.org}Ocsigen project}.
+
+{1 Manual}
+
+- {{!page-quickstart}Quick start}: install and run your first server.
+- {{!page-launching}Launching the server}
+- {{!page-config}Configuration file}
+- {{!page-staticlink}Using Ocsigen Server as a library}
+
+{1 Extensions}
+
+Ocsigen Server is extensible. The bundled extensions are:
+{{!page-staticmod}Staticmod} (serve static files),
+{{!page-eliom}Eliom} (the Web framework),
+{{!page-extendconfiguration}Extendconfiguration},
+{{!page-accesscontrol}Accesscontrol},
+{{!page-authbasic}Authbasic},
+{{!page-deflatemod}Deflatemod} (compression),
+{{!page-redirectmod}Redirectmod},
+{{!page-revproxy}Revproxy} (reverse proxy),
+{{!page-rewritemod}Rewritemod},
+{{!page-outputfilter}Outputfilter},
+{{!page-userconf}Userconf} and
+{{!page-cors}CORS}.
+
+{1 Developer documentation}
+
+- {{!page-extend}Writing an extension}
+
+{1 API reference}
+
+See the {{!page-api}API reference}.

--- a/doc/quickstart.mld
+++ b/doc/quickstart.mld
@@ -1,6 +1,7 @@
+@short_title Quick start
 
 {0 Ocsigen Server}
-  
+
 
 
 Ocsigen Server is a powerful and modular generic purpose Web Server.


### PR DESCRIPTION
## Goal

On ocaml.org the documentation landing page of a package (`/p/<pkg>/latest/doc/`)
is rendered from the package's `doc/index.mld`. Ocsigen Server had none, so odoc
generated a bare library listing instead of a real home page, and the manual pages
were not presented in any logical order in the sidebar.

This is the first step of a wider effort to make the Ocsigen documentation
complete and well-formed on ocaml.org (it will be picked up at the next release).

## Changes

- Add `doc/index.mld`: a proper home page introducing Ocsigen Server and linking
  to the manual pages and the API reference. It uses `@children_order` so the
  sidebar follows a logical reading order (Quick start, Launching, Configuration,
  …, Extensions, then API) instead of the alphabetical default.
- Add a `@short_title` to `quickstart.mld`: its heading is "Ocsigen Server"
  (it is the landing page on ocsigen.org). Since the new home page is also titled
  "Ocsigen Server", the `@short_title` makes the quick start appear as
  "Quick start" in the sidebar/breadcrumbs, avoiding a duplicate entry, without
  changing the page heading.

## Verification

`dune build @doc` succeeds with odoc 3.2.1; `index.mld` and all its
`{!page-…}` references resolve with no new warnings; the generated landing page
is the new home page and lists every manual page in the `@children_order` order.