### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -9,7 +9,8 @@
 ;; ocsigenserver/.
 (project ocsigenserver)
 (title Server)
-(pub /ocsigenserver)
+(url-prefix /ocsigenserver)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (landing ocsigenserver/index.html)
 (manual-root)
 (nav


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps ocsigenserver's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.

The doc CI tracks wodoc master, so no CI change is needed.