### PR TITLE
doc: link Eliom with an odoc reference instead of a hardcoded URL

### DIFF
--- a/doc/eliom.mld
+++ b/doc/eliom.mld
@@ -2,4 +2,4 @@
 
 {e Eliom} is a powerful framework for programming Web applications in OCaml.
 
-See the full documentation {{:https://ocsigen.org/eliom/}here}.
+See the full documentation {{!/eliom/page-index}here}.

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -36,3 +36,9 @@
     (link "Writing an extension" ocsigenserver/extend.html extend))
   (api-section "API"
     (link "API reference" ocsigenserver/api.html api)))
+
+;; Sibling Ocsigen projects this doc links to, so wodoc rewrites their
+;; ocaml.org cross-references to relative links into their deployed docs on
+;; ocsigen.org. (pkg deploy-dir layout wrapper-module)
+(hosted
+  (eliom eliom true Eliom))


### PR DESCRIPTION
Part of the cross-project-links effort. The Eliom extension page (`doc/eliom.mld`) linked to Eliom's documentation with a hardcoded `https://ocsigen.org/eliom/` URL, which always sends the reader off to ocsigen.org (even from ocaml.org).

Use the odoc cross-package reference `{{!/eliom/page-index}}`: odoc resolves it to `/p/eliom` on ocaml.org (keeping the reader there), and wodoc rewrites it to Eliom's deployed docs on ocsigen.org via a new `(hosted (eliom eliom true Eliom))` entry. The page compiles with `odoc compile`; the multilib page-ref rewrite is unit-tested in wodoc `test/deps.t`.