### PR TITLE
doc: document public request/response/command modules

### DIFF
--- a/doc/api.mld
+++ b/doc/api.mld
@@ -23,6 +23,16 @@ Userconf
 Cors
 }
 
+{2 Requests and responses}
+
+{!modules:
+Ocsigen_request
+Ocsigen_response
+Ocsigen_multipart
+Ocsigen_cookie_map
+Ocsigen_charset_mime
+}
+
 {2 Persistent data, writing in the logs, configuration file extension, polymorphic tables}
 
 {!modules:
@@ -41,4 +51,6 @@ Ocsigen_extensions
 Ocsigen_local_files
 Ocsigen_header
 Ocsigen_stream
+Ocsigen_loader
+Ocsigen_command
 }


### PR DESCRIPTION
Several public modules have generated odoc pages but were absent from the curated API reference (`doc/api.mld`), so they did not appear in the API navigation.

This adds them:
- a new **Requests and responses** section: `Ocsigen_request`, `Ocsigen_response`, `Ocsigen_multipart`, `Ocsigen_cookie_map`, `Ocsigen_charset_mime`;
- under **Extending Ocsigen Server**: `Ocsigen_loader`, `Ocsigen_command`.

`Ocsigen_request`/`Ocsigen_response` are the core request/response types used throughout the extension API, so their absence was the most visible gap. Doc-only change.