### PR TITLE
One-command serve mode (ocsigenserver ./public)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
 ==== 8.0.0~dev ===
+ * One-command serve mode: "ocsigenserver ./public" (or
+   "ocsigenserver --serve ./public --port 8000 --directory-listing") now
+   serves a directory of static files without any configuration file or
+   pre-created log directory. The Staticmod extension is loaded on demand.
  * Documentation: the manual now lives in the main branch as odoc pages
    (doc/*.mld), compiled in place by `dune build @doc`, replacing the
    wikicreole manual of the wikidoc branch. doc/index.mld is the package

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@
    "ocsigenserver --serve ./public --port 8000 --directory-listing") now
    serves a directory of static files without any configuration file or
    pre-created log directory. The Staticmod extension is loaded on demand.
+ * Logging: when no <logdir> (and no <syslog>) is given in the configuration
+   file, logs now go to the standard output and standard error instead of to
+   files, so that no log directory is required.
  * Documentation: the manual now lives in the main branch as odoc pages
    (doc/*.mld), compiled in place by `dune build @doc`, replacing the
    wikicreole manual of the wikidoc branch. doc/index.mld is the package

--- a/doc/config.mld
+++ b/doc/config.mld
@@ -257,6 +257,10 @@ v}
 
 The directory for log files. Usually [/var/log/ocsigenserver]. Ocsigenserver is using three log files: [access.log] where all requests are logged, [errors.log] for error messages, and [warnings.log] for warnings.
 
+If [<logdir>] is omitted (and [<syslog>] is not used), the logs are written to
+the standard output and standard error instead of to files, so that no log
+directory is required.
+
 Example :
 
 

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -18,8 +18,25 @@ It is written in OCaml and uses the
 
 {1 Installation}
 
-The easier way to install Ocsigenserver is to use the [opam] package 
+The easier way to install Ocsigenserver is to use the [opam] package
 manager. Ocsigen Server is also available in Linux distributions.
+
+{1 Quick start: serving a directory in one command}
+
+To serve the static files of a directory without writing any configuration
+file, just give the directory to [ocsigenserver]:
+{v
+ocsigenserver ./public
+v}
+This starts a server on port 8080 serving the files of [./public]. No
+configuration file and no log directory are needed: the logs go to the
+terminal. A few options are available:
+{v
+ocsigenserver --serve ./public --port 8000 --directory-listing
+v}
+This is the simplest way to get started. For anything more elaborate (several
+hosts, extensions, reverse proxy, etc.) use a configuration file or the library
+API, as described below.
 
 {1 Using Ocsigen Server as an executable}
 

--- a/doc/launching.mld
+++ b/doc/launching.mld
@@ -6,6 +6,18 @@ To run the server, use the command [ocsigenserver]. It has the
 following options:
 
 {v
+  DIR, --serve DIR
+         Serve the static files of directory DIR without a configuration
+         file (logs go to the terminal). DIR can also be given as a plain
+         positional argument: "ocsigenserver ./public".
+
+  -P, --port
+         Port to listen on in serve mode (default 8080).
+
+  --directory-listing
+         In serve mode, list the contents of directories that have no
+         index file.
+
   -c, --config
          Alternate configuration file.
 

--- a/src/extensions/staticmod.ml
+++ b/src/extensions/staticmod.ml
@@ -380,3 +380,7 @@ let run ?dir ?regexp ?dest ?code ?cache ?root () =
          root)
   in
   fun _ _ _ -> gen ~usermode:None ?cache kind
+
+(* Publish the serving function so that the one-command serve mode can use it
+   after loading this extension dynamically, without a static dependency. *)
+let () = Ocsigen.Server.register_static_server (fun ~dir -> run ~dir ())

--- a/src/ocsigenserver.ml
+++ b/src/ocsigenserver.ml
@@ -1,6 +1,42 @@
+let usage = "usage: ocsigenserver [-c configfile | [--serve] DIR [options]]"
+let section = Logs.Src.create "ocsigen:main"
+
+(* Report command-line errors through Logs. A stderr reporter is installed
+   below so that these messages are visible before the server configures its own
+   logging. *)
+let () = Logs.set_reporter Ocsigen.Messages.stdio_reporter
+
+let fatal fmt =
+  Format.kasprintf
+    (fun msg ->
+       Logs.err ~src:section (fun m -> m "%s" msg);
+       exit 2)
+    fmt
+
+(* Serve-mode options. When a directory to serve is given (either through
+   [--serve] or as a positional argument), the server starts without a
+   configuration file. Otherwise the legacy configuration-file path is used. *)
+let serve_dir = ref None
+let serve_port = ref None
+let directory_listing = ref false
+let config_given = ref false
+
+let set_serve_dir d =
+  match !serve_dir with
+  | None -> serve_dir := Some d
+  | Some d' when d' = d -> ()
+  | Some _ -> fatal "only one directory to serve can be given"
+
+let set_configfile f =
+  config_given := true;
+  Ocsigen.Config.set_configfile f
+
 let () =
   let alt_msg =
     "Alternate config file (default " ^ Ocsigen.Config.get_config_file () ^ ")"
+  and serve_msg = "Serve the static files of DIR without a configuration file"
+  and port_msg = "Port to listen on in serve mode (default 8080)"
+  and listing_msg = "List directory contents in serve mode (when no index file)"
   and silent_msg = "Silent mode (error messages in errors.log only)"
   and pid_msg = "Specify a file where to write the PIDs of servers"
   and daemon_msg = "Daemon mode (detach the process)"
@@ -10,8 +46,12 @@ let () =
   and version_msg = "Display version number and exit" in
   try
     Arg.parse_argv Sys.argv
-      [ "-c", Arg.String Ocsigen.Config.set_configfile, alt_msg
-      ; "--config", Arg.String Ocsigen.Config.set_configfile, alt_msg
+      [ "-c", Arg.String set_configfile, alt_msg
+      ; "--config", Arg.String set_configfile, alt_msg
+      ; "--serve", Arg.String set_serve_dir, serve_msg
+      ; "-P", Arg.Int (fun p -> serve_port := Some p), port_msg
+      ; "--port", Arg.Int (fun p -> serve_port := Some p), port_msg
+      ; "--directory-listing", Arg.Set directory_listing, listing_msg
       ; "-s", Arg.Unit Ocsigen.Config.set_silent, silent_msg
       ; "--silent", Arg.Unit Ocsigen.Config.set_silent, silent_msg
       ; "-p", Arg.String Ocsigen.Config.set_pidfile, pid_msg
@@ -27,8 +67,31 @@ let () =
       ; "-d", Arg.Unit Ocsigen.Config.set_daemon, daemon_msg
       ; "--daemon", Arg.Unit Ocsigen.Config.set_daemon, daemon_msg
       ; "--version", Arg.Unit Ocsigen.Config.display_version, version_msg ]
-      (fun _ -> ())
-      "usage: ocsigenserver [-c configfile]"
+      set_serve_dir usage
   with Arg.Help s -> print_endline s; exit 0
 
-let () = Ocsigen.Server.exec (Ocsigen.Parseconfig.parse_config ())
+(* Resolve [dir] to an absolute path and check that it is an existing directory.
+   The directory is never created. *)
+let check_serve_dir dir =
+  let dir =
+    if Filename.is_relative dir
+    then Filename.concat (Sys.getcwd ()) dir
+    else dir
+  in
+  match Sys.is_directory dir with
+  | true -> dir
+  | false -> fatal "%s is not a directory" dir
+  | exception Sys_error _ -> fatal "no such directory: %s" dir
+
+let () =
+  match !serve_dir with
+  | Some dir ->
+      if !config_given
+      then fatal "-c/--config cannot be combined with serve mode";
+      let dir = check_serve_dir dir in
+      Ocsigen.Server.serve ~dir ?port:!serve_port
+        ~directory_listing:!directory_listing ()
+  | None ->
+      if !serve_port <> None || !directory_listing
+      then fatal "--port and --directory-listing require a directory to serve";
+      Ocsigen.Server.exec (Ocsigen.Parseconfig.parse_config ())

--- a/src/ocsigenserver.ml
+++ b/src/ocsigenserver.ml
@@ -68,7 +68,9 @@ let () =
       ; "--daemon", Arg.Unit Ocsigen.Config.set_daemon, daemon_msg
       ; "--version", Arg.Unit Ocsigen.Config.display_version, version_msg ]
       set_serve_dir usage
-  with Arg.Help s -> print_endline s; exit 0
+  with
+  | Arg.Help s -> print_endline s; exit 0
+  | Arg.Bad s -> fatal "%s" (String.trim s)
 
 (* Resolve [dir] to an absolute path and check that it is an existing directory.
    The directory is never created. *)

--- a/src/server/Ocsigen/config.ml
+++ b/src/server/Ocsigen/config.ml
@@ -51,6 +51,7 @@ let set_global_log_level lvl =
 (* General config *)
 let verbose = ref false
 let silent = ref false
+let log_to_stderr = ref false
 let daemon = ref false
 let veryverbose = ref false
 let debug = ref false
@@ -98,6 +99,7 @@ let set_verbose () =
   set_global_log_level (Some Logs.Warning)
 
 let set_silent () = silent := true
+let set_log_to_stderr b = log_to_stderr := b
 
 let set_daemon () =
   set_silent ();
@@ -153,6 +155,7 @@ let get_pidfile () = !pidfile
 let get_mimefile () = !mimefile
 let get_verbose () = !verbose
 let get_silent () = !silent
+let get_log_to_stderr () = !log_to_stderr
 let get_daemon () = !daemon
 let get_veryverbose () = !veryverbose
 let get_debug () = !debug

--- a/src/server/Ocsigen/config.mli
+++ b/src/server/Ocsigen/config.mli
@@ -56,6 +56,12 @@ val set_pidfile : string -> unit
 val set_mimefile : string -> unit
 val set_verbose : unit -> unit
 val set_silent : unit -> unit
+
+val set_log_to_stderr : bool -> unit
+(** When set to [true], logs are written to [stdout]/[stderr] instead of the log
+    files under {!get_logdir}. Used by the one-command serve mode so that no log
+    directory needs to exist. *)
+
 val set_daemon : unit -> unit
 val set_veryverbose : unit -> unit
 val set_debug : unit -> unit
@@ -91,6 +97,7 @@ val get_pidfile : unit -> string option
 val get_mimefile : unit -> string
 val get_verbose : unit -> bool
 val get_silent : unit -> bool
+val get_log_to_stderr : unit -> bool
 val get_daemon : unit -> bool
 val get_veryverbose : unit -> bool
 val get_debug : unit -> bool

--- a/src/server/Ocsigen/messages.ml
+++ b/src/server/Ocsigen/messages.ml
@@ -76,6 +76,75 @@ let stdio_reporter =
         in
         r.Logs.report src level ~over k msgf) }
 
+let log_to_stdio () =
+  Logs.set_reporter stdio_reporter;
+  Lwt.return ()
+
+(* Write logs to the access/warnings/errors files in the log directory. *)
+let open_log_files_in_dir () =
+  let open_channel path =
+    let path = full_path path in
+    try
+      let channel =
+        open_out_gen
+          [Open_append; Open_wronly; Open_creat; Open_text]
+          0o640 path
+      in
+      channel, fun () -> close_out_noerr channel
+    with
+    | Unix.Unix_error (error, _, _) ->
+        raise
+          (Config.Config_file_error
+             (Printf.sprintf "can't open log file %s: %s" path
+                (Unix.error_message error)))
+    | exn -> raise exn
+  in
+  let open_log path =
+    let channel, close = open_channel path in
+    make_reporter channel, close
+  in
+  let acc = open_log access_file in
+  let war = open_log warning_file in
+  let err = open_log error_file in
+  close_loggers := [snd acc; snd war; snd err];
+  Logs.set_reporter
+    (let broadcast_reporters =
+       [ { Logs.report =
+             (fun src _level ~over k msgf ->
+               let r =
+                 if Logs.Src.equal src access_sect
+                 then fst acc
+                 else Logs.nop_reporter
+               in
+               r.Logs.report src Error ~over k msgf) }
+       ; (let dispatch_f =
+           fun _sect lev ->
+            match lev with
+            | Logs.Error -> fst err
+            | Logs.Warning -> fst war
+            | _ -> Logs.nop_reporter
+          in
+          { Logs.report =
+              (fun src level ~over k msgf ->
+                (dispatch_f src level).Logs.report src level ~over k msgf) })
+       ; (let dispatch_f =
+           fun _sect lev ->
+            if Config.get_silent ()
+            then Logs.nop_reporter
+            else
+              match lev with Logs.Warning | Logs.Error -> stderr | _ -> stdout
+          in
+          { Logs.report =
+              (fun src level ~over k msgf ->
+                (dispatch_f src level).Logs.report src level ~over k msgf) }) ]
+     in
+     { Logs.report =
+         (fun src level ~over k msgf ->
+           List.fold_left
+             (fun k r () -> r.Logs.report src level ~over k msgf)
+             k broadcast_reporters ()) });
+  Lwt.return ()
+
 let open_log_files () =
   match Config.get_syslog_facility () with
   | Some facility ->
@@ -95,83 +164,17 @@ let open_log_files () =
                  k broadcast_reporters ()) });
       Lwt.return ()
   | None ->
-      (* log to files *)
-      let open_channel path =
-        let path = full_path path in
-        try
-          let channel =
-            open_out_gen
-              [Open_append; Open_wronly; Open_creat; Open_text]
-              0o640 path
-          in
-          channel, fun () -> close_out_noerr channel
-        with
-        | Unix.Unix_error (error, _, _) ->
-            raise
-              (Config.Config_file_error
-                 (Printf.sprintf "can't open log file %s: %s" path
-                    (Unix.error_message error)))
-        | exn -> raise exn
-      in
-      let open_log path =
-        let channel, close = open_channel path in
-        make_reporter channel, close
-      in
-      let acc = open_log access_file in
-      let war = open_log warning_file in
-      let err = open_log error_file in
-      close_loggers := [snd acc; snd war; snd err];
-      Logs.set_reporter
-        (let broadcast_reporters =
-           [ { Logs.report =
-                 (fun src _level ~over k msgf ->
-                   let r =
-                     if Logs.Src.equal src access_sect
-                     then fst acc
-                     else Logs.nop_reporter
-                   in
-                   r.Logs.report src Error ~over k msgf) }
-           ; (let dispatch_f =
-               fun _sect lev ->
-                match lev with
-                | Logs.Error -> fst err
-                | Logs.Warning -> fst war
-                | _ -> Logs.nop_reporter
-              in
-              { Logs.report =
-                  (fun src level ~over k msgf ->
-                    (dispatch_f src level).Logs.report src level ~over k msgf)
-              })
-           ; (let dispatch_f =
-               fun _sect lev ->
-                if Config.get_silent ()
-                then Logs.nop_reporter
-                else
-                  match lev with
-                  | Logs.Warning | Logs.Error -> stderr
-                  | _ -> stdout
-              in
-              { Logs.report =
-                  (fun src level ~over k msgf ->
-                    (dispatch_f src level).Logs.report src level ~over k msgf)
-              }) ]
-         in
-         { Logs.report =
-             (fun src level ~over k msgf ->
-               List.fold_left
-                 (fun k r () -> r.Logs.report src level ~over k msgf)
-                 k broadcast_reporters ()) });
-      Lwt.return ()
+      (* When no log directory is configured, log to stdout/stderr instead of
+         creating files in the current directory. *)
+      if Config.get_logdir () = ""
+      then log_to_stdio ()
+      else open_log_files_in_dir ()
 
 let open_files () =
   (* CHECK: we are closing asynchronously! That should be ok, though. *)
   List.iter (fun close -> close ()) !close_loggers;
   close_loggers := [];
-  if Config.get_log_to_stderr ()
-  then (
-    Logs.set_reporter stdio_reporter;
-    Lwt.return ())
-  else open_log_files ()
+  if Config.get_log_to_stderr () then log_to_stdio () else open_log_files ()
 
 (****)
 

--- a/src/server/Ocsigen/messages.ml
+++ b/src/server/Ocsigen/messages.ml
@@ -63,10 +63,20 @@ let stderr = make_reporter stderr
 let stdout = make_reporter stdout
 let close_loggers = ref []
 
-let open_files () =
-  (* CHECK: we are closing asynchronously! That should be ok, though. *)
-  List.iter (fun close -> close ()) !close_loggers;
-  close_loggers := [];
+(* Reporter used in serve mode: access messages go to [stdout], warnings and
+   errors to [stderr], everything else to [stdout]. No log files are opened. *)
+let stdio_reporter =
+  { Logs.report =
+      (fun src level ~over k msgf ->
+        let r =
+          if Logs.Src.equal src access_sect
+          then stdout
+          else
+            match level with Logs.Warning | Logs.Error -> stderr | _ -> stdout
+        in
+        r.Logs.report src level ~over k msgf) }
+
+let open_log_files () =
   match Config.get_syslog_facility () with
   | Some facility ->
       (* log to syslog *)
@@ -152,6 +162,16 @@ let open_files () =
                  (fun k r () -> r.Logs.report src level ~over k msgf)
                  k broadcast_reporters ()) });
       Lwt.return ()
+
+let open_files () =
+  (* CHECK: we are closing asynchronously! That should be ok, though. *)
+  List.iter (fun close -> close ()) !close_loggers;
+  close_loggers := [];
+  if Config.get_log_to_stderr ()
+  then (
+    Logs.set_reporter stdio_reporter;
+    Lwt.return ())
+  else open_log_files ()
 
 (****)
 

--- a/src/server/Ocsigen/messages.mli
+++ b/src/server/Ocsigen/messages.mli
@@ -43,6 +43,12 @@ val unexpected_exception : exn -> string -> unit
 val error_log_path : unit -> string
 (** Path to the error log file *)
 
+val stdio_reporter : Logs.reporter
+(** A reporter that writes access messages to [stdout] and warnings and errors
+    to [stderr], without opening any log file. It is used by the one-command
+    serve mode and to report command-line errors before the logging system is
+    configured. *)
+
 (**/**)
 
 val open_files : unit -> unit Lwt.t

--- a/src/server/Ocsigen/server.ml
+++ b/src/server/Ocsigen/server.ml
@@ -474,3 +474,40 @@ let start
   main (fun () ->
     Extensions.start_initialisation ();
     Extensions.set_hosts instructions)
+
+(* Registry through which the Staticmod extension, once loaded, publishes its
+   static-file serving function. This lets the one-command serve mode use the
+   extension without statically linking it (which would clash with the
+   configuration-file path, where the extension is loaded dynamically). *)
+let static_server : (dir:string -> instruction) option ref = ref None
+let register_static_server f = static_server := Some f
+
+let serve ?(port = 8080) ?(directory_listing = false) ~dir () =
+  (* One-command serve mode: no configuration file and no log directory are
+     required. Logs go to stderr and the command pipe is placed in a temporary
+     location so that the usual control commands remain available. *)
+  Config.set_log_to_stderr true;
+  Config.set_command_pipe
+    (Filename.concat
+       (Filename.get_temp_dir_name ())
+       (Printf.sprintf "ocsigenserver-%d.cmd" (Unix.getpid ())));
+  (* Load the Staticmod extension on demand. It registers its serving function
+     through [register_static_server]. *)
+  (try
+     Ocsigen_base.Loader.loadfiles
+       (fun () -> ())
+       (fun () -> ())
+       false
+       (Ocsigen_base.Loader.findfiles "ocsigenserver.ext.staticmod")
+   with e ->
+     let msg, errno = errmsg e in
+     Messages.errlog msg; exit errno);
+  match !static_server with
+  | None ->
+      Messages.errlog
+        "The Staticmod extension did not register its serving function";
+      exit 1
+  | Some static ->
+      start
+        ~ports:[`All, port]
+        [host ~list_directory_content:directory_listing [static ~dir]]

--- a/src/server/Ocsigen/server.mli
+++ b/src/server/Ocsigen/server.mli
@@ -28,6 +28,15 @@ val reload : ?file:string -> unit -> unit
 val exec : Xml.xml list list -> unit
 (** Start the server with a configuration file. Never returns. *)
 
+val serve : ?port:int -> ?directory_listing:bool -> dir:string -> unit -> unit
+(** [serve ~dir ()] starts a server that serves the static files of directory
+    [dir], with no configuration file and no log directory required (logs go to
+    [stdout]/[stderr]). This backs the one-command serve mode of the
+    [ocsigenserver] executable ([ocsigenserver ./public]). The Staticmod
+    extension is loaded dynamically on demand, so it does not need to be linked
+    into the program. [port] defaults to 8080. When [directory_listing] is
+    [true], directories without an index file are listed. Never returns. *)
+
 val start :
    ?ports:(Config.Socket_type.t * int) list
   -> ?ssl_ports:(Config.Socket_type.t * int) list
@@ -79,6 +88,11 @@ type instruction =
   -> Extensions.extension
 (** The type of instructions to be used inside an host or site.
     Instructions are defined by extensions (Staticmod, Eliom, etc.) *)
+
+val register_static_server : (dir:string -> instruction) -> unit
+(** Called by the Staticmod extension when it is loaded to publish its
+    static-file serving function, so that {!serve} can use it without a static
+    dependency on the extension. *)
 
 val host :
    ?regexp:string

--- a/test/dune
+++ b/test/dune
@@ -5,3 +5,8 @@
   (deps
    ../server-test-helpers.sh
    (package ocsigenserver))))
+
+(cram
+ (package ocsigenserver)
+ (deps
+  (package ocsigenserver)))

--- a/test/serve.t/run.t
+++ b/test/serve.t/run.t
@@ -1,0 +1,35 @@
+Serve a directory with a single command, with no configuration file and no
+pre-created log directory.
+
+  $ mkdir www
+  $ printf '<html>hello</html>' > www/index.html
+
+Start the server in serve mode on a TCP port. Logs go to stderr (redirected to
+a file here), so no log directory is created.
+
+  $ ocsigenserver --serve www --port 8061 >server.log 2>&1 &
+  $ SERVER_PID=$!
+  $ trap 'kill $SERVER_PID 2>/dev/null' EXIT
+
+An existing file is served with the correct content type and body. The
+unreproducible "date" header is filtered out.
+
+  $ curl -s -i --retry 20 --retry-delay 1 --retry-connrefused --user-agent "" \
+  >   http://127.0.0.1:8061/index.html | grep -v "^date: "
+  HTTP/1.1 200 OK
+  content-type: text/html
+  server: Ocsigen
+  content-length: 18
+
+  <html>hello</html> (no-eol)
+
+A missing file gives a 404.
+
+  $ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8061/nope.html
+  404
+
+No log directory is created in the current directory.
+
+  $ ls
+  server.log
+  www


### PR DESCRIPTION
## What

Adds a zero-config, one-command serve mode so that a directory of static files
can be served without writing a configuration file or pre-creating a log
directory, matching the ease of use of `caddy file-server` or
`python -m http.server`:

```
ocsigenserver ./public
ocsigenserver --serve ./public --port 8000 --directory-listing
```

- `--serve DIR` (or a plain positional `DIR`), `-P`/`--port` (default 8080),
  `--directory-listing`.
- Logs go to stdout/stderr (new `Config.log_to_stderr` option); no log
  directory is required. The command pipe is placed in a temporary location so
  the usual control commands still work.
- The configuration-file path (`-c`) is unchanged.

## Design

The serve logic lives in the library as `Server.serve`. Rather than statically
linking the Staticmod extension (which would clash with the configuration-file
path, where the extension is loaded dynamically — Dynlink refuses to load an
already-linked module), Staticmod is **loaded on demand**. Because the
`ocsigenserver` library cannot depend on the Staticmod extension (which depends
on it), Staticmod publishes its serving function through a small registry
(`Server.register_static_server`) when it is loaded, and `Server.serve`
retrieves it from there. The binary and the configuration-file behaviour are
therefore unchanged.

Command-line errors are reported through `Logs` (never directly to
stdout/stderr) and exit with code 2.

## Tests

`test/serve.t` starts the server in serve mode on a TCP port and checks that a
file is served with the correct content type and body, that a missing file
gives a 404, and that no log directory is created in the current directory.
Verified manually that the configuration-file path still works (Staticmod
loaded dynamically, no double-loading).

## Follow-ups (not in this PR)

- `--reverse-proxy URL` using the same registry pattern.
- Conditional requests (ETag / Last-Modified) and range requests.