### PR TITLE
Conditional requests for static files (ETag / Last-Modified / 304)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@
  * Logging: when no <logdir> (and no <syslog>) is given in the configuration
    file, logs now go to the standard output and standard error instead of to
    files, so that no log directory is required.
+ * Static files: serve an ETag and a Last-Modified header, and answer
+   conditional requests (If-None-Match / If-Modified-Since) with 304 Not
+   Modified (RFC 7232).
  * Documentation: the manual now lives in the main branch as odoc pages
    (doc/*.mld), compiled in place by `dune build @doc`, replacing the
    wikicreole manual of the wikidoc branch. doc/index.mld is the package

--- a/doc/staticmod.mld
+++ b/doc/staticmod.mld
@@ -1,6 +1,11 @@
 {0 Staticmod}
 Staticmod is a module allowing to serve static pages (files).
 
+Served files carry an [ETag] (weak, derived from the file's modification time
+and size) and a [Last-Modified] header. Conditional requests made with
+[If-None-Match] or [If-Modified-Since] are answered with [304 Not Modified]
+when the file is unchanged (RFC 7232), saving bandwidth on revalidation.
+
 {1 Using as a library}
 To use that extension as a library for your OCaml programs,
 load OCamlfind package [ocsigenserver.ext.staticmod],

--- a/src/extensions/staticmod.ml
+++ b/src/extensions/staticmod.ml
@@ -216,7 +216,12 @@ let gen ~usermode ?cache dir = function
         in
         (match page with
           | Ocsigen.Local_files.RFile fname ->
-              Ocsigen.Response.respond_file fname
+              let header name = Ocsigen.Request.header request_info name in
+              Ocsigen.Response.respond_file
+                ?if_none_match:(header Ocsigen_http.Header.Name.if_none_match)
+                ?if_modified_since:
+                  (header Ocsigen_http.Header.Name.if_modified_since)
+                fname
           | Ocsigen.Local_files.RDir dname ->
               respond_dir pathstring dname >>= fun answer ->
               Lwt.return @@ Ocsigen.Response.of_cohttp answer)

--- a/src/server/Ocsigen/response.ml
+++ b/src/server/Ocsigen/response.ml
@@ -60,50 +60,95 @@ let respond_not_found ?uri () =
   in
   respond_string ~status:`Not_found ~body ()
 
-let respond_file ?headers ?(status = `OK) fname =
+(* Weak entity-tag built from the file's modification time and size. *)
+let weak_etag ~mtime ~size = Printf.sprintf "W/\"%x-%x\"" mtime size
+
+(* Does the [If-None-Match] header value match [etag]? Handles ["*"] and a
+   comma-separated list of entity-tags. *)
+let if_none_match_matches if_none_match etag =
+  let if_none_match = String.trim if_none_match in
+  String.equal if_none_match "*"
+  || List.exists
+       (fun t -> String.equal (String.trim t) etag)
+       (String.split_on_char ',' if_none_match)
+
+let respond_file
+      ?headers
+      ?(status = `OK)
+      ?if_none_match
+      ?if_modified_since
+      fname
+  =
   let exception Isnt_a_file in
   (* Copied from [cohttp-lwt-unix] and adapted to [Body]. *)
   Lwt.catch
     (fun () ->
        (* Check this isn't a directory first *)
-       let* () =
-         let* s = Lwt_unix.stat fname in
-         if Unix.(s.st_kind <> S_REG)
-         then raise Isnt_a_file
-         else Lwt.return_unit
-       in
-       let count = 16384 in
-       let* ic =
-         Lwt_io.open_file ~buffer:(Lwt_bytes.create count) ~mode:Lwt_io.input
-           fname
-       in
-       let* len = Lwt_io.length ic in
-       let encoding = Http.Transfer.Fixed len in
-       let stream write =
-         let rec cat_loop () =
-           Lwt.bind (Lwt_io.read ~count ic) (function
-             | "" -> Lwt.return_unit
-             | buf -> Lwt.bind (write buf) cat_loop)
+       let* s = Lwt_unix.stat fname in
+       if Unix.(s.st_kind <> S_REG)
+       then raise Isnt_a_file
+       else
+         let last_modified = Ocsigen_base.Lib.Date.to_string s.Unix.st_mtime in
+         let etag =
+           weak_etag ~mtime:(int_of_float s.Unix.st_mtime) ~size:s.Unix.st_size
          in
-         let* () =
-           Lwt.catch cat_loop (fun exn ->
-             Logs.warn (fun m ->
-               m "Error resolving file %s (%s)" fname (Printexc.to_string exn));
-             Lwt.return_unit)
+         (* Validators sent with both [200] and [304] responses (RFC 7232). *)
+         let add_validators h =
+           Http.Header.add
+             (Http.Header.add h "etag" etag)
+             "last-modified" last_modified
          in
-         Lwt.catch
-           (fun () -> Lwt_io.close ic)
-           (fun e ->
-              Logs.warn (fun f ->
-                f "Closing channel failed: %s" (Printexc.to_string e));
-              Lwt.return_unit)
-       in
-       let body = Body.make encoding stream in
-       let mime_type = Magic_mime.lookup fname in
-       let headers =
-         Http.Header.add_opt_unless_exists headers "content-type" mime_type
-       in
-       Lwt.return (respond ~headers ~status ~body ()))
+         let headers = Option.value headers ~default:(Http.Header.init ()) in
+         (* [If-None-Match] takes precedence over [If-Modified-Since]
+            (RFC 7232). For the latter we only return [304] on an exact match of
+            our [Last-Modified] value, so we never answer [304] wrongly. *)
+         let not_modified =
+           match if_none_match with
+           | Some inm -> if_none_match_matches inm etag
+           | None -> (
+             match if_modified_since with
+             | Some ims -> String.equal ims last_modified
+             | None -> false)
+         in
+         if not_modified
+         then
+           Lwt.return
+             (respond ~headers:(add_validators headers) ~status:`Not_modified ())
+         else
+           let count = 16384 in
+           let* ic =
+             Lwt_io.open_file ~buffer:(Lwt_bytes.create count)
+               ~mode:Lwt_io.input fname
+           in
+           let* len = Lwt_io.length ic in
+           let encoding = Http.Transfer.Fixed len in
+           let stream write =
+             let rec cat_loop () =
+               Lwt.bind (Lwt_io.read ~count ic) (function
+                 | "" -> Lwt.return_unit
+                 | buf -> Lwt.bind (write buf) cat_loop)
+             in
+             let* () =
+               Lwt.catch cat_loop (fun exn ->
+                 Logs.warn (fun m ->
+                   m "Error resolving file %s (%s)" fname
+                     (Printexc.to_string exn));
+                 Lwt.return_unit)
+             in
+             Lwt.catch
+               (fun () -> Lwt_io.close ic)
+               (fun e ->
+                  Logs.warn (fun f ->
+                    f "Closing channel failed: %s" (Printexc.to_string e));
+                  Lwt.return_unit)
+           in
+           let body = Body.make encoding stream in
+           let mime_type = Magic_mime.lookup fname in
+           let headers =
+             add_validators
+               (Http.Header.add_unless_exists headers "content-type" mime_type)
+           in
+           Lwt.return (respond ~headers ~status ~body ()))
     (function
       | Unix.Unix_error (Unix.ENOENT, _, _) | Isnt_a_file ->
           Lwt.return (respond_not_found ())

--- a/src/server/Ocsigen/response.mli
+++ b/src/server/Ocsigen/response.mli
@@ -60,10 +60,15 @@ val respond_error :
 val respond_file :
    ?headers:Cohttp.Header.t
   -> ?status:Http.Status.t
+  -> ?if_none_match:string
+  -> ?if_modified_since:string
   -> string
   -> t Lwt.t
 (** Respond with the content of a file. The content type is guessed using
-    [Magic_mime]. *)
+    [Magic_mime]. An [ETag] (weak, derived from the file's modification time and
+    size) and a [Last-Modified] header are always added. If the request's
+    [If-None-Match] or [If-Modified-Since] header is passed and matches, the
+    response is [304 Not Modified] with an empty body (RFC 7232). *)
 
 val update :
    ?response:Cohttp.Response.t

--- a/test/conditional-requests.t/run.t
+++ b/test/conditional-requests.t/run.t
@@ -1,0 +1,39 @@
+Static files are served with validators (ETag and Last-Modified), and
+conditional requests are answered with 304 Not Modified.
+
+  $ mkdir www
+  $ printf 'cacheable content' > www/f.txt
+  $ ocsigenserver --serve www --port 8065 >server.log 2>&1 &
+  $ SERVER_PID=$!
+  $ trap 'kill $SERVER_PID 2>/dev/null' EXIT
+
+A normal request succeeds and carries both validators:
+
+  $ curl -s -D headers -o /dev/null --retry 20 --retry-delay 1 \
+  >   --retry-connrefused http://127.0.0.1:8065/f.txt
+  $ grep -io '^etag:' headers
+  etag:
+  $ grep -io '^last-modified:' headers
+  last-modified:
+
+Re-requesting with the returned ETag yields 304 Not Modified with an empty body:
+
+  $ ETAG=$(grep -i '^etag:' headers | sed 's/^[^:]*: //' | tr -d '\r')
+  $ curl -s -o body -w '%{http_code}\n' -H "If-None-Match: $ETAG" \
+  >   http://127.0.0.1:8065/f.txt
+  304
+  $ wc -c < body
+  0
+
+Re-requesting with the returned Last-Modified date also yields 304:
+
+  $ LM=$(grep -i '^last-modified:' headers | sed 's/^[^:]*: //' | tr -d '\r')
+  $ curl -s -o /dev/null -w '%{http_code}\n' -H "If-Modified-Since: $LM" \
+  >   http://127.0.0.1:8065/f.txt
+  304
+
+A non-matching ETag still serves the file:
+
+  $ curl -s -o /dev/null -w '%{http_code}\n' -H 'If-None-Match: W/"nomatch"' \
+  >   http://127.0.0.1:8065/f.txt
+  200


### PR DESCRIPTION
## What

Static files are now served with validators and honour conditional requests, so
browsers and caches can revalidate cheaply (RFC 7232) — even `python -m http.server`
did this and we did not.

- Every static response carries a weak **ETag** (derived from the file's
  modification time and size) and a **Last-Modified** header.
- A request with **If-None-Match** (or, as a fallback, **If-Modified-Since**)
  that matches gets **304 Not Modified** with an empty body, keeping the
  validators.

## Where

`Response.respond_file` gained the ETag/Last-Modified generation and optional
`?if_none_match` / `?if_modified_since` parameters; Staticmod passes the
request's headers. If-None-Match takes precedence over If-Modified-Since per
RFC 7232; the latter only returns 304 on an exact match of our Last-Modified
value, so it never answers 304 wrongly.

## Tests

`test/conditional-requests.t` checks the validators are present, that
re-requesting with either validator returns 304 with an empty body, and that a
non-matching ETag still serves the file.

## Note

Independent of #297 (reverse proxy); both branch from master.