### PR TITLE
doc: convert leftover wikicreole definition lists to bullet lists

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -101,30 +101,18 @@ some modules.
 
 The extensions provided are:
 
-;{{!page-staticmod}Staticmod}
-:for serving static pages,
-;{{!page-accesscontrol}Accesscontrol}
-:if you need to restrict the access to the sites,
-;{{!page-eliom}Eliom}
-:if you want to use dynamic Web and mobile applications written in OCaml with Eliom,
-;{{!page-revproxy}Revproxy}
-:if you want to redirect some requests to another Web server,.
-;{{!page-redirectmod}Redirectmod}
-:if you want to define some HTTP redirections,
-;{{!page-deflatemod}Deflatemod}
-:if you want to compress the content before sending your pages,
-;{{!page-outputfilter}Outputfilter}
-:allows to change the header of the HTTP response,
-;{{!page-rewritemod}Rewritemod}
-:allows to rewrite the request before continuing,
-;{{!page-extendconfiguration}Extendconfiguration}
-:adds many useful configuration options,
-;{{!page-authbasic}Authbasic}
-:for basic HTTP authentication,
-;{{!page-cors}CORS}
-:for settings CORS options,
-;{{!page-userconf}Userconf}
-:for allowing local users to have personal pages,
+- {{!page-staticmod}Staticmod}: for serving static pages,
+- {{!page-accesscontrol}Accesscontrol}: if you need to restrict the access to the sites,
+- {{!page-eliom}Eliom}: if you want to use dynamic Web and mobile applications written in OCaml with Eliom,
+- {{!page-revproxy}Revproxy}: if you want to redirect some requests to another Web server,.
+- {{!page-redirectmod}Redirectmod}: if you want to define some HTTP redirections,
+- {{!page-deflatemod}Deflatemod}: if you want to compress the content before sending your pages,
+- {{!page-outputfilter}Outputfilter}: allows to change the header of the HTTP response,
+- {{!page-rewritemod}Rewritemod}: allows to rewrite the request before continuing,
+- {{!page-extendconfiguration}Extendconfiguration}: adds many useful configuration options,
+- {{!page-authbasic}Authbasic}: for basic HTTP authentication,
+- {{!page-cors}CORS}: for settings CORS options,
+- {{!page-userconf}Userconf}: for allowing local users to have personal pages,
 
 If you are using a configuration, file, use tag 
 [<extension/>] to load an exetnsion (see examples in the

--- a/doc/migration.mld
+++ b/doc/migration.mld
@@ -52,12 +52,9 @@ compiling without changes: just add the package to your [dune] file.
 
 The shims are split to mirror the libraries they alias:
 
-;[ocsigenserver-compat]
-:old server names ([Ocsigen_server], [Ocsigen_extensions], [Ocsigen_config], ...)
-;[ocsigenserver-compat.baselib]
-:old base-library names ([Ocsigen_lib], [Ocsigen_cache], ...)
-;[ocsigenserver-compat.http]
-:old HTTP names ([Ocsigen_header], [Ocsigen_charset_mime])
+- [ocsigenserver-compat]: old server names ([Ocsigen_server], [Ocsigen_extensions], [Ocsigen_config], ...)
+- [ocsigenserver-compat.baselib]: old base-library names ([Ocsigen_lib], [Ocsigen_cache], ...)
+- [ocsigenserver-compat.http]: old HTTP names ([Ocsigen_header], [Ocsigen_charset_mime])
 
 For example, to keep using the old names in an executable:
 {v


### PR DESCRIPTION
The extensions list in `doc/index.mld` and the compat-shim list in `doc/migration.mld` still used wikicreole definition-list syntax (`;term` / `:definition`), which odoc does not understand and rendered literally (the leading `;` and `:` were visible on the page).

Convert each pair to a proper odoc bullet item (`- term: definition`). Verified: the list now renders as `<li>` items with working links. Doc-only change.