### PR TITLE
Log accesses in the Combined Log Format

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,10 @@
  * Logging: when no <logdir> (and no <syslog>) is given in the configuration
    file, logs now go to the standard output and standard error instead of to
    files, so that no log directory is required.
+ * Access log: requests are now logged in the standard Apache/nginx Combined
+   Log Format, understood by common log analysers, instead of the previous
+   custom format. The line now reports the final status code, the response
+   size and the authenticated user.
  * Documentation: the manual now lives in the main branch as odoc pages
    (doc/*.mld), compiled in place by `dune build @doc`, replacing the
    wikicreole manual of the wikidoc branch. doc/index.mld is the package

--- a/doc/config.mld
+++ b/doc/config.mld
@@ -257,9 +257,25 @@ v}
 
 The directory for log files. Usually [/var/log/ocsigenserver]. Ocsigenserver is using three log files: [access.log] where all requests are logged, [errors.log] for error messages, and [warnings.log] for warnings.
 
+Requests are logged in the standard Apache/nginx
+{{:https://httpd.apache.org/docs/current/logs.html#combined}Combined Log
+Format}:
+
+{v
+%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"
+v}
+
+that is, client address, identity ([-]), authenticated user (set by an
+authentication extension such as {{!page-authbasic}Authbasic}, [-] otherwise), request
+time, request line, response status, response size in bytes ([-] when unknown,
+for example for a streamed response), then the [Referer] and [User-Agent]
+headers. This format is understood out of the box by log analysers such as
+GoAccess, AWStats or Apache's own tools.
+
 If [<logdir>] is omitted (and [<syslog>] is not used), the logs are written to
 the standard output and standard error instead of to files, so that no log
-directory is required.
+directory is required. In that case the access lines go to the standard output
+in the very same Combined Log Format.
 
 Example :
 

--- a/src/baselib/Ocsigen_base/lib.mli
+++ b/src/baselib/Ocsigen_base/lib.mli
@@ -107,4 +107,9 @@ end
 module Date : sig
   val to_string : float -> string
   (** Converts Unix GMT date to string *)
+
+  val name_of_month : int -> string
+  (** Three-letter English abbreviation of a month, [0] for January to [11] for
+      December (as in {!Unix.tm.tm_mon}).
+      @raise Failure if the argument is out of range. *)
 end

--- a/src/extensions/authbasic.ml
+++ b/src/extensions/authbasic.ml
@@ -65,21 +65,26 @@ let gen ~realm ~auth rs =
       (Ocsigen.Ocsigen_cohttp.Ocsigen_http_error
          (Ocsigen_cookie_map.empty, `Bad_request))
   in
-  let validate ~err s =
+  let validate ~err ~request s =
     match Cohttp.Auth.credential_of_string s with
     | `Basic (user, pass) ->
         auth user pass >>= fun b ->
-        if b then Lwt.return (Ocsigen.Extensions.Ext_next err) else reject ()
+        if b
+        then (
+          (* Record the authenticated user for the access log (%u field). *)
+          Ocsigen.Request.set_remote_user request user;
+          Lwt.return (Ocsigen.Extensions.Ext_next err))
+        else reject ()
     | `Other _s -> invalid_header ()
   in
   match rs with
   | Ocsigen.Extensions.Req_not_found (err, ri) -> (
-    match
-      Ocsigen.Request.header ri.Ocsigen.Extensions.request_info
-        Ocsigen_http.Header.Name.authorization
-    with
-    | Some s -> validate ~err s
-    | None -> reject ())
+      let request = ri.Ocsigen.Extensions.request_info in
+      match
+        Ocsigen.Request.header request Ocsigen_http.Header.Name.authorization
+      with
+      | Some s -> validate ~err ~request s
+      | None -> reject ())
   | Ocsigen.Extensions.Req_found _ ->
       Lwt.return Ocsigen.Extensions.Ext_do_nothing
 

--- a/src/server/Ocsigen/messages.ml
+++ b/src/server/Ocsigen/messages.ml
@@ -26,27 +26,13 @@ let full_path f = Filename.concat (Config.get_logdir ()) f
 let error_log_path () = full_path error_file
 
 (* This is the date format inherited from [Lwt_log]. *)
-let pp_date ppf =
-  let time = Unix.gettimeofday () in
-  let tm = Unix.localtime time in
-  let month_string =
-    match tm.Unix.tm_mon with
-    | 0 -> "Jan"
-    | 1 -> "Feb"
-    | 2 -> "Mar"
-    | 3 -> "Apr"
-    | 4 -> "May"
-    | 5 -> "Jun"
-    | 6 -> "Jul"
-    | 7 -> "Aug"
-    | 8 -> "Sep"
-    | 9 -> "Oct"
-    | 10 -> "Nov"
-    | 11 -> "Dec"
-    | _ -> ""
-  in
-  Format.fprintf ppf "%s %2d %02d:%02d:%02d" month_string tm.Unix.tm_mday
-    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+let date_string () =
+  let tm = Unix.localtime (Unix.gettimeofday ()) in
+  Printf.sprintf "%s %2d %02d:%02d:%02d"
+    (Ocsigen_base.Lib.Date.name_of_month tm.Unix.tm_mon)
+    tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+let pp_date ppf = Format.pp_print_string ppf (date_string ())
 
 let make_reporter out_channel =
   let ppf = Format.formatter_of_out_channel out_channel in
@@ -63,21 +49,35 @@ let stderr = make_reporter stderr
 let stdout = make_reporter stdout
 let close_loggers = ref []
 
-(* Reporter used in serve mode: access messages go to [stdout], warnings and
-   errors to [stderr], everything else to [stdout]. No log files are opened. *)
+(* Access logging bypasses Logs and Format: a complete Combined Log Format line
+   is written directly to the output channel. [access_out] is installed by
+   [open_files] according to the logging mode. *)
+let access_out = ref (fun (_ : string) -> ())
+let write_line oc s = output_string oc s; output_char oc '\n'; flush oc
+
+(* Echo an access line on the console with the same readable date/source prefix
+   as the other logs ([access.log] keeps the verbatim Combined format). *)
+let console_access oc s =
+  Printf.fprintf oc "%s: %s: %s\n%!" (date_string ())
+    (Logs.Src.name access_sect)
+    s
+
+(* Reporter for the non-access logs in serve mode: warnings and errors to
+   [stderr], everything else to [stdout]. Access lines are written directly to
+   [stdout] (see [log_to_stdio]). Also used to report command-line errors
+   before the logging system is configured. *)
 let stdio_reporter =
   { Logs.report =
       (fun src level ~over k msgf ->
         let r =
-          if Logs.Src.equal src access_sect
-          then stdout
-          else
-            match level with Logs.Warning | Logs.Error -> stderr | _ -> stdout
+          match level with Logs.Warning | Logs.Error -> stderr | _ -> stdout
         in
         r.Logs.report src level ~over k msgf) }
 
 let log_to_stdio () =
   Logs.set_reporter stdio_reporter;
+  (* In serve mode the terminal is the access log. *)
+  access_out := write_line Stdlib.stdout;
   Lwt.return ()
 
 (* Write logs to the access/warnings/errors files in the log directory. *)
@@ -103,21 +103,19 @@ let open_log_files_in_dir () =
     let channel, close = open_channel path in
     make_reporter channel, close
   in
-  let acc = open_log access_file in
+  let acc_channel, acc_close = open_channel access_file in
   let war = open_log warning_file in
   let err = open_log error_file in
-  close_loggers := [snd acc; snd war; snd err];
+  close_loggers := [acc_close; snd war; snd err];
+  (* Access lines: verbatim Combined format to [access.log], plus a prefixed
+     echo on the console (unless silent). *)
+  (access_out :=
+     fun s ->
+       write_line acc_channel s;
+       if not (Config.get_silent ()) then console_access Stdlib.stdout s);
   Logs.set_reporter
     (let broadcast_reporters =
-       [ { Logs.report =
-             (fun src _level ~over k msgf ->
-               let r =
-                 if Logs.Src.equal src access_sect
-                 then fst acc
-                 else Logs.nop_reporter
-               in
-               r.Logs.report src Error ~over k msgf) }
-       ; (let dispatch_f =
+       [ (let dispatch_f =
            fun _sect lev ->
             match lev with
             | Logs.Error -> fst err
@@ -162,6 +160,9 @@ let open_log_files () =
                List.fold_left
                  (fun k r () -> r.Logs.report src level ~over k msgf)
                  k broadcast_reporters ()) });
+      (* No access.log file in syslog mode: access lines reach syslog (and
+         stderr) through Logs. *)
+      (access_out := fun s -> Logs.app ~src:access_sect (fun fmt -> fmt "%s" s));
       Lwt.return ()
   | None ->
       (* When no log directory is configured, log to stdout/stderr instead of
@@ -178,7 +179,7 @@ let open_files () =
 
 (****)
 
-let accesslog s = Logs.app ~src:access_sect (fun fmt -> fmt "%s" s)
+let accesslog s = !access_out s
 let errlog ?section s = Logs.err ?src:section (fun fmt -> fmt "%s" s)
 let warning ?section s = Logs.warn ?src:section (fun fmt -> fmt "%s" s)
 

--- a/src/server/Ocsigen/messages.mli
+++ b/src/server/Ocsigen/messages.mli
@@ -44,10 +44,10 @@ val error_log_path : unit -> string
 (** Path to the error log file *)
 
 val stdio_reporter : Logs.reporter
-(** A reporter that writes access messages to [stdout] and warnings and errors
-    to [stderr], without opening any log file. It is used by the one-command
-    serve mode and to report command-line errors before the logging system is
-    configured. *)
+(** A reporter that writes warnings and errors to [stderr] and everything else
+    to [stdout], without opening any log file. It is used by the one-command
+    serve mode (where access lines are written directly to [stdout]) and to
+    report command-line errors before the logging system is configured. *)
 
 (**/**)
 

--- a/src/server/Ocsigen/ocsigen_cohttp.ml
+++ b/src/server/Ocsigen/ocsigen_cohttp.ml
@@ -54,6 +54,89 @@ module Cookie = struct
     Ocsigen_cookie_map.Map_path.fold serialize_cookies cookies headers
 end
 
+(* Access log in the Apache/nginx Combined Log Format:
+   %h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"
+   https://httpd.apache.org/docs/current/logs.html#combined *)
+module Access_log = struct
+  (* Offset of local time from UTC, in minutes, robust across day boundaries. *)
+  let timezone_offset t =
+    let l = Unix.localtime t and u = Unix.gmtime t in
+    let day_diff =
+      if l.Unix.tm_year <> u.Unix.tm_year
+      then compare l.Unix.tm_year u.Unix.tm_year
+      else compare l.Unix.tm_yday u.Unix.tm_yday
+    in
+    (((day_diff * 24) + l.Unix.tm_hour - u.Unix.tm_hour) * 60)
+    + l.Unix.tm_min - u.Unix.tm_min
+
+  let time t =
+    let tm = Unix.localtime t in
+    let off = timezone_offset t in
+    let sign = if off < 0 then '-' else '+' in
+    let off = abs off in
+    Printf.sprintf "[%02d/%s/%04d:%02d:%02d:%02d %c%02d%02d]" tm.Unix.tm_mday
+      (Ocsigen_base.Lib.Date.name_of_month tm.Unix.tm_mon)
+      (1900 + tm.Unix.tm_year) tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+      sign (off / 60) (off mod 60)
+
+  (* Escape characters that would break the format or allow log injection in
+     attacker-controlled fields (request line, Referer, User-Agent). *)
+  let escape s =
+    let buf = Buffer.create (String.length s) in
+    String.iter
+      (fun c ->
+         match c with
+         | '"' -> Buffer.add_string buf "\\\""
+         | '\\' -> Buffer.add_string buf "\\\\"
+         | '\n' -> Buffer.add_string buf "\\n"
+         | '\r' -> Buffer.add_string buf "\\r"
+         | '\t' -> Buffer.add_string buf "\\t"
+         | c when Char.code c < 0x20 || Char.code c = 0x7f ->
+             Buffer.add_string buf (Printf.sprintf "\\x%02x" (Char.code c))
+         | c -> Buffer.add_char buf c)
+      s;
+    Buffer.contents buf
+
+  let line request response =
+    let quoted s = "\"" ^ escape s ^ "\"" in
+    let header name =
+      match Request.header request name with
+      | Some s -> quoted s
+      | None -> "\"-\""
+    in
+    let user =
+      match Request.remote_user request with
+      | Some u when u <> "" -> escape u
+      | _ -> "-"
+    in
+    let request_line =
+      (* string_of_version already yields "HTTP/1.1". *)
+      Printf.sprintf "%s %s %s"
+        (Cohttp.Code.string_of_method (Request.meth request))
+        (Uri.path_and_query (Request.uri request))
+        (Cohttp.Code.string_of_version (Request.version request))
+    in
+    let status =
+      Cohttp.Code.code_of_status
+        (Response.status response :> Cohttp.Code.status_code)
+    in
+    (* The response size is carried by the body transfer encoding, not a
+       header: known for fixed-length bodies (e.g. static files), "-" when
+       streamed with an unknown length. *)
+    let bytes =
+      match Response.Body.transfer_encoding (Response.body response) with
+      | Cohttp.Transfer.Fixed n -> Int64.to_string n
+      | Cohttp.Transfer.Chunked | Cohttp.Transfer.Unknown -> "-"
+    in
+    Printf.sprintf "%s - %s %s %s %d %s %s %s"
+      (Request.client_ip_to_string request)
+      user
+      (time (Request.timeofday request))
+      (quoted request_line) status bytes
+      (header Ocsigen_http.Header.Name.referer)
+      (header Ocsigen_http.Header.Name.user_agent)
+end
+
 let handler ~ssl ~address ~port ~connector (flow, conn) request body =
   let filenames = ref [] in
   let edn = Conduit_lwt_unix.endp_of_flow flow in
@@ -115,18 +198,6 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
   in
   Lwt.finalize
     (fun () ->
-       Messages.accesslog
-         (Format.sprintf "connection for %s from %s (%s)%s: %s"
-            (match Request.host request with
-            | None -> "<host not specified in the request>"
-            | Some h -> h)
-            (Request.client_conn_to_string request)
-            (Option.value ~default:""
-               (Request.header request Ocsigen_http.Header.Name.user_agent))
-            (Option.fold ~none:""
-               ~some:(fun s -> " X-Forwarded-For: " ^ s)
-               (Request.header request Ocsigen_http.Header.Name.x_forwarded_for))
-            (Uri.path (Request.uri request)));
        Lwt.catch
          (fun () -> connector request)
          (function
@@ -137,7 +208,9 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
                and status = `Moved_permanently in
                Lwt.return (Response.respond_string ~headers ~status ~body:"" ())
            | exn -> Lwt.return (handle_error exn))
-       >>= fun response -> Lwt.return (Response.to_response_expert response))
+       >>= fun response ->
+       Messages.accesslog (Access_log.line request response);
+       Lwt.return (Response.to_response_expert response))
     (fun () ->
        if !filenames <> []
        then

--- a/src/server/Ocsigen/request.ml
+++ b/src/server/Ocsigen/request.ml
@@ -284,6 +284,28 @@ let client_conn_to_string {r_client_conn = c; _} =
   | `Forwarded_for ip -> "forwarded:" ^ ip
   | `Unknown -> "unknown"
 
+(* Unlike [client_conn_to_string], which is meant for human-readable debug logs
+   and adds scheme prefixes ("unix:", "forwarded:", "unknown"), this returns a
+   bare value valid for the Combined Log Format %h field. *)
+let client_ip_to_string {r_client_conn = c; _} =
+  match c with
+  | `Inet (ip, _) -> Ipaddr.to_string ip
+  | `Forwarded_for ip -> ip
+  | `Unix path when path <> "" -> path
+  | `Unix _ | `Unknown -> "-"
+
+(* The user authenticated by an authentication extension (e.g. authbasic),
+   stored in the request cache so that the access log can report it. *)
+let remote_user_key : string Polytables.key = Polytables.make_key ()
+
+let set_remote_user r user =
+  Polytables.set ~table:r.r_request_cache ~key:remote_user_key ~value:user
+
+let remote_user r =
+  match Polytables.get ~table:r.r_request_cache ~key:remote_user_key with
+  | user -> Some user
+  | exception Not_found -> None
+
 let forward_ip {r_forward_ip; _} = r_forward_ip
 let request_cache {r_request_cache; _} = r_request_cache
 let tries {r_tries; _} = r_tries

--- a/src/server/Ocsigen/request.mli
+++ b/src/server/Ocsigen/request.mli
@@ -90,6 +90,19 @@ val client_conn : t -> client_conn
 val client_conn_to_string : t -> string
 (** A textual representation of [client_conn] suitable for use in logs. *)
 
+val client_ip_to_string : t -> string
+(** The bare client IP address (no scheme prefix), suitable for the [%h] field
+    of a Common/Combined access-log line. Returns ["-"] when the address is
+    unknown. *)
+
+val set_remote_user : t -> string -> unit
+(** [set_remote_user r user] records the name of the user authenticated for
+    this request (typically by {!Authbasic}). It is stored in the request cache
+    and reported as the [%u] field of the access log. *)
+
+val remote_user : t -> string option
+(** The user authenticated for this request, if any. See {!set_remote_user}. *)
+
 val forward_ip : t -> string list
 val content_type : t -> content_type option
 val request_cache : t -> Polytables.t

--- a/test/access-log.t/run.t
+++ b/test/access-log.t/run.t
@@ -1,0 +1,40 @@
+Accesses are logged in the Apache/nginx Combined Log Format.
+
+  $ mkdir www
+  $ printf '<html>hello</html>' > www/index.html
+
+Start the server in serve mode. Access lines go to stdout (redirected here to a
+file), with no date/source prefix so the standard format is preserved.
+
+  $ ocsigenserver --serve www --port 8062 >server.log 2>&1 &
+  $ SERVER_PID=$!
+  $ trap 'kill $SERVER_PID 2>/dev/null' EXIT
+
+Request a file with a known User-Agent and Referer.
+
+  $ curl -s -o /dev/null --retry 20 --retry-delay 1 --retry-connrefused \
+  >   --user-agent "test-agent" --referer "http://example.test/" \
+  >   http://127.0.0.1:8062/index.html
+
+The access line follows the Combined Log Format:
+%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i". The timestamp is masked
+because it is not reproducible. There is no authenticated user (%u is "-"), and
+%b is the response size (18 bytes, from Content-Length).
+
+  $ for _ in $(seq 1 20); do
+  >   grep -q 'GET /index.html' server.log && break
+  >   sleep 0.5
+  > done
+  $ grep 'GET /index.html' server.log | sed 's/\[[^]]*\]/[TIME]/'
+  127.0.0.1 - - [TIME] "GET /index.html HTTP/1.1" 200 18 "http://example.test/" "test-agent"
+
+A missing file is logged too, with the 404 status and "-" for the absent
+Referer and User-Agent.
+
+  $ curl -s -o /dev/null --user-agent "" http://127.0.0.1:8062/nope.html
+  $ for _ in $(seq 1 20); do
+  >   grep -q 'GET /nope.html' server.log && break
+  >   sleep 0.5
+  > done
+  $ grep 'GET /nope.html' server.log | sed 's/\[[^]]*\]/[TIME]/'
+  127.0.0.1 - - [TIME] "GET /nope.html HTTP/1.1" 404 16 "-" "-"

--- a/test/extensions/deflatemod.t/run.t
+++ b/test/extensions/deflatemod.t/run.t
@@ -1,26 +1,22 @@
   $ source ../../server-test-helpers.sh
   $ run_server ./test.exe
   ocsigen:main: [WARNING] Command pipe created
-  ocsigen:access:  connection for local-test from unix: (): /index.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./index.html".
   ocsigen:local-file: [INFO] checking if file index.html can be sent
   ocsigen:ext: [INFO] Compiling exclusion regexp $^
   ocsigen:local-file: [INFO] Returning "./index.html".
-  ocsigen:access:  connection for local-test from unix: (): /index.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./index.html".
   ocsigen:local-file: [INFO] checking if file index.html can be sent
   ocsigen:local-file: [INFO] Returning "./index.html".
-  ocsigen:access:  connection for local-test from unix: (): /empty_dir/
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./empty_dir/".
   ocsigen:local-file: [INFO] Testing "./empty_dir/index.html" as possible index.
   ocsigen:local-file: [INFO] No index and no listing
-  ocsigen:access:  connection for local-test from unix: (): /doesnt_exists.html
   ocsigen:ext: [INFO] host found! local-test:0 matches .* 
   ocsigen:ext:staticmod: [INFO] Is it a static file?
   ocsigen:local-file: [INFO] Testing "./doesnt_exists.html".

--- a/test/server-test-helpers.sh
+++ b/test/server-test-helpers.sh
@@ -13,7 +13,9 @@ run_server ()
   mkdir -p log data # Directories that might be required by the server
   dune build "$1"
   # Run the server in the background, cut the datetime out of the log output.
-  dune exec -- "$@" 2>&1 | cut -b 18- &
+  # Access lines (Combined Log Format) carry their own timestamp, which is not
+  # reproducible, so drop them from the captured log.
+  dune exec -- "$@" 2>&1 | cut -b 18- | grep -v "^ocsigen:access:" &
   # Wait for the unix-domain socket and the command-pipe to be created
   local timeout=50 # Don't wait more than 0.5s
   while ! ( [[ -e ./local.sock ]] && [[ -e ./local.cmd ]] ) && (( timeout-- > 0 )); do


### PR DESCRIPTION
## Summary

Replace the custom, human-readable access-log line with the standard
Apache/nginx **Combined Log Format**, so the access log is understood out of
the box by common analysers (GoAccess, AWStats, Apache tools).

```
%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"
```

Example:

```
127.0.0.1 - - [26/Jun/2026:14:55:36 +0200] "GET /index.html HTTP/1.1" 200 18 "http://example.test/" "test-agent"
```

## What changed

- **Request**: `remote_user`/`set_remote_user` (stored in the request cache, the
  `%u` field) and `client_ip_to_string` (bare `%h`, `-` when unknown).
- **authbasic**: records the authenticated user on successful Basic auth.
- **ocsigen_cohttp**: the line is built *after* the response is produced, so it
  carries the final status code and the response size (taken from the body
  transfer encoding; `-` when streamed with an unknown length). The request
  line, `Referer` and `User-Agent` are quote-escaped against log injection, and
  the timestamp uses the CLF `[dd/Mon/yyyy:HH:MM:SS +zzzz]` form.
- **messages**: access lines are written verbatim (no date/source/level prefix,
  which would break the format). In file mode they go to `access.log` only and
  are no longer echoed to the human-readable console.

## Notes

- The previous custom format is removed (no compatibility option). Consumers of
  the old `connection for ... from ...` line must switch to the Combined format.
- **Behaviour change**: in file-log mode, access lines are no longer also echoed
  to stdout; they live only in `access.log`.

## Tests

- New cram test `test/access-log.t`: asserts the Combined line for a 200 (with
  `Referer`/`User-Agent`) and a 404, with the timestamp masked.
- `deflatemod.t` updated: access lines are no longer echoed to the console.