### PR TITLE
Compression: add zstd, switch backend to bytesrw, compress by default in serve mode

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.28.1
+version=0.29.0
 break-cases=fit
 break-collection-expressions=fit-or-vertical
 break-fun-decl=wrap

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
 ==== 8.0.0~dev ===
+ * Compression: the Deflatemod extension now supports the zstd
+   content-encoding (RFC 8878) in addition to gzip and deflate, and its
+   backend was switched from camlzip to bytesrw. Compression is enabled by
+   default in the one-command serve mode.
  * One-command serve mode: "ocsigenserver ./public" (or
    "ocsigenserver --serve ./public --port 8000 --directory-listing") now
    serves a directory of static files without any configuration file or

--- a/doc/deflatemod.mld
+++ b/doc/deflatemod.mld
@@ -6,13 +6,17 @@
 
 {2 What is deflatemod?}
 
-Deflatemod is a module for Ocsigen that allows you to
-deflate content, using HTTP/1.1 mechanism. It supports gzip as well as
-deflate.
+Deflatemod is a module for Ocsigen that compresses content using the
+HTTP [Content-Encoding] mechanism. It supports [gzip], [deflate] (zlib
+format) and [zstd].
+
+Brotli ([br]) is not supported yet: at the time of writing there is no
+maintained OCaml binding to libbrotli that builds on OCaml 5.
 
 {2 What do I need to use deflatemod?}
 
-You need the camlzip library by Xavier Leroy and a working Ocsigen
+You need the [bytesrw] library (with its [zlib] and [zstd] backends, which
+require the system [zlib] and [libzstd] libraries) and a working Ocsigen
 installation.
 
 {2 How do I use deflatemod?}
@@ -35,8 +39,9 @@ Again, the options are in ocsigen.conf. You can set a few options globally, in t
 
 - the compress level: from 0 (no compression) to 9. The higher, the
   better compression rate you achieve. Conversely, the lower, the faster
-  it is. Default is 6.
-- the buffer size: default is 1024. You shouldn't need to change this
+  it is. Default is 6. This level applies to [gzip] and [deflate]; [zstd]
+  uses the library default level.
+- the buffer size: default is 8192. You shouldn't need to change this
   one, but you can still try a few other values (any feedback welcomed).
 
 For example:
@@ -96,10 +101,18 @@ Limitations: you cannot filter by directory or by filename extension (remember e
 
 {1 Technical questions}
 
-{2 How can I choose the content-encoding (gzip or deflate)?}
+{2 How can I choose the content-encoding (gzip, deflate or zstd)?}
 
 You can't. Deflatemod follows the RFC and chooses automatically the
-right encoding, based upon Accept-encoding header sent by the client.
+right encoding, based upon the [Accept-Encoding] header sent by the client.
+When the client offers several codecs at the same quality, [zstd] is
+preferred, then [gzip], then [deflate].
+
+{2 Is compression enabled in the one-command serve mode?}
+
+Yes. When you run [ocsigenserver ./public] (or [ocsigenserver --serve ...]),
+responses with a text-based content type are compressed by default, with no
+configuration needed, just like a static file server such as Caddy.
 
 {2 Does deflatemod support transfert-encoding?}
 

--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,7 @@
   (ocaml (>= 4.14))
   (bytesrw (>= 0.3.0))
   conf-zlib
+  conf-zstd
   (cohttp-lwt-unix (>= 6.0))
   conduit-lwt-unix
   http

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,8 @@
  (maintenance_intent "(latest)")
  (depends
   (ocaml (>= 4.14))
-  (camlzip (>= 1.08))
+  (bytesrw (>= 0.3.0))
+  conf-zlib
   (cohttp-lwt-unix (>= 6.0))
   conduit-lwt-unix
   http

--- a/ocsigenserver.opam
+++ b/ocsigenserver.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "bytesrw" {>= "0.3.0"}
   "conf-zlib"
+  "conf-zstd"
   "cohttp-lwt-unix" {>= "6.0"}
   "conduit-lwt-unix"
   "http"

--- a/ocsigenserver.opam
+++ b/ocsigenserver.opam
@@ -12,7 +12,8 @@ bug-reports: "https://github.com/ocsigen/ocsigenserver/issues"
 depends: [
   "dune" {>= "3.19"}
   "ocaml" {>= "4.14"}
-  "camlzip" {>= "1.08"}
+  "bytesrw" {>= "0.3.0"}
+  "conf-zlib"
   "cohttp-lwt-unix" {>= "6.0"}
   "conduit-lwt-unix"
   "http"

--- a/src/extensions/deflatemod.ml
+++ b/src/extensions/deflatemod.ml
@@ -81,7 +81,7 @@ let compress_body (cfilter : Bytesrw.Bytes.Writer.filter) body =
   flush_out ()
 
 (* We implement Content-Encoding, not Transfer-Encoding *)
-type encoding = Deflate | Gzip | Id | Star | Not_acceptable
+type encoding = Deflate | Gzip | Zstd | Id | Star | Not_acceptable
 
 let qvalue = function Some x -> x | None -> 1.0
 
@@ -92,6 +92,8 @@ let enc_compare e e' =
   | (_, v), (_, v') when v < v' -> 1 (* then, sort by qvalue *)
   | (_, v), (_, v') when v > v' -> -1
   | (x, _), (x', _) when x = x' -> 0
+  | (Zstd, _), (_, _) -> -1 (* zstd is preferred at equal qvalue *)
+  | (_, _), (Zstd, _) -> 1
   | (Deflate, _), (_, _) -> 1 (* and subsort by encoding *)
   | (_, _), (Deflate, _) -> -1
   | (Gzip, _), (_, _) -> 1
@@ -108,6 +110,7 @@ let rec filtermap f = function
 let convert = function
   | Some "deflate", v -> Some (Deflate, qvalue v)
   | Some "gzip", v | Some "x-gzip", v -> Some (Gzip, qvalue v)
+  | Some "zstd", v -> Some (Zstd, qvalue v)
   | Some "identity", v -> Some (Id, qvalue v)
   | None, v -> Some (Star, qvalue v)
   | _ -> None
@@ -195,6 +198,12 @@ let filter choice_list = function
         stream_filter
           (Bytesrw_zlib.Gzip.compress_writes ~level:!compress_level ())
           "gzip" "Gdeflatemod"
+          (Ocsigen.Request.sub_path_string ri)
+          choice_list res
+    | Zstd ->
+        stream_filter
+          (Bytesrw_zstd.compress_writes ())
+          "zstd" "Zdeflatemod"
           (Ocsigen.Request.sub_path_string ri)
           choice_list res
     | Id | Star ->

--- a/src/extensions/deflatemod.ml
+++ b/src/extensions/deflatemod.ml
@@ -65,9 +65,9 @@ let compress_body (cfilter : Bytesrw.Bytes.Writer.filter) body =
   let flush_out () =
     if Buffer.length out = 0
     then Lwt.return_unit
-    else (
+    else
       let s = Buffer.contents out in
-      Buffer.clear out; flush s)
+      Buffer.clear out; flush s
   in
   let write f =
     try f () with Bytesrw.Bytes.Stream.Error e -> raise (stream_error e)

--- a/src/extensions/deflatemod.ml
+++ b/src/extensions/deflatemod.ml
@@ -44,98 +44,41 @@ let set_compress_level i = compress_level := if i >= 0 && i <= 9 then i else 6
 let buffer_size = ref 8192
 let set_buffer_size s = buffer_size := if s > 0 then s else 8192
 
-(* Minimal header, by X. Leroy *)
-let gzip_header_length = 10
+(* Compression backend, provided by bytesrw. A codec is given as a bytesrw
+   writer filter (see [compress_body]). *)
 
-let gzip_header =
-  let gzip_header = Bytes.make gzip_header_length (Char.chr 0) in
-  Bytes.set gzip_header 0 @@ Char.chr 0x1F;
-  Bytes.set gzip_header 1 @@ Char.chr 0x8B;
-  Bytes.set gzip_header 2 @@ Char.chr 8;
-  Bytes.set gzip_header 9 @@ Char.chr 0xFF;
-  Bytes.unsafe_to_string gzip_header
+let stream_error e =
+  Ocsigen_base.Ocsigen_stream.Stream_error
+    ("Error during compression: " ^ Bytesrw.Bytes.Stream.error_message e)
 
-(* inspired by an auxiliary function from camlzip, by Xavier Leroy *)
-type output_buffer =
-  { stream : Zlib.stream
-  ; buf : bytes
-  ; flush : string -> unit Lwt.t
-  ; mutable size : int32
-  ; mutable crc : int32 }
+(* Compress [body] with the bytesrw writer filter [cfilter], pushing each
+   produced chunk to [flush].
 
-let write_int32 buf offset n =
-  for i = 0 to 3 do
-    Bytes.set buf (offset + i)
-      (Char.chr (Int32.to_int (Int32.shift_right_logical n (8 * i)) land 0xff))
-  done
-
-let compress_flush oz used_out =
-  Logs.debug ~src:section (fun fmt -> fmt "Flushing %d bytes" used_out);
-  if used_out > 0
-  then oz.flush (Bytes.sub_string oz.buf 0 used_out)
-  else Lwt.return_unit
-
-(* gzip trailer *)
-let write_trailer oz =
-  write_int32 oz.buf 0 oz.crc;
-  write_int32 oz.buf 4 oz.size;
-  compress_flush oz 8
-
-(* puts in oz the content of buf, from pos to pos + len ; *)
-let rec compress_output oz inbuf pos len =
-  if len = 0
-  then Lwt.return_unit
-  else
-    let (_ : bool), used_in, used_out =
-      try
-        Zlib.deflate_string oz.stream inbuf pos len oz.buf 0
-          (Bytes.length oz.buf) Zlib.Z_NO_FLUSH
-      with Zlib.Error (s, s') ->
-        raise
-          (Ocsigen_base.Ocsigen_stream.Stream_error
-             ("Error during compression: " ^ s ^ " " ^ s'))
-    in
-    compress_flush oz used_out >>= fun () ->
-    compress_output oz inbuf (pos + used_in) (len - used_in)
-
-let rec compress_finish oz =
-  Logs.debug ~src:section (fun fmt -> fmt "Finishing");
-  (* loop until there is nothing left to compress and flush *)
-  let finished, (_ : int), used_out =
-    Zlib.deflate oz.stream oz.buf 0 0 oz.buf 0 (Bytes.length oz.buf)
-      Zlib.Z_FINISH
-  in
-  compress_flush oz used_out >>= fun () ->
-  if not finished then compress_finish oz else Lwt.return_unit
-
-(* deflate param : true = deflate ; false = gzip (no header in this case) *)
-let compress_body deflate body =
+   bytesrw writers are synchronous, whereas [flush] is an Lwt operation. We let
+   the compressor write its output into an in-memory buffer, then flush that
+   buffer downstream after each input chunk. This bridges the synchronous
+   compressor with the Lwt output stream without ever blocking. *)
+let compress_body (cfilter : Bytesrw.Bytes.Writer.filter) body =
  fun flush ->
-  let zstream = Zlib.deflate_init !compress_level deflate in
-  let oz =
-    let buffer_size = !buffer_size in
-    { stream = zstream
-    ; buf = Bytes.create buffer_size
-    ; flush
-    ; size = 0l
-    ; crc = 0l }
+  let out = Buffer.create !buffer_size in
+  let cw = cfilter ~eod:true (Bytesrw.Bytes.Writer.of_buffer out) in
+  let flush_out () =
+    if Buffer.length out = 0
+    then Lwt.return_unit
+    else (
+      let s = Buffer.contents out in
+      Buffer.clear out; flush s)
   in
-  (if deflate then Lwt.return_unit else flush gzip_header) >>= fun () ->
+  let write f =
+    try f () with Bytesrw.Bytes.Stream.Error e -> raise (stream_error e)
+  in
   body (fun inbuf ->
-    let len = String.length inbuf in
-    oz.size <- Int32.add oz.size (Int32.of_int len);
-    oz.crc <- Zlib.update_crc_string oz.crc inbuf 0 len;
-    compress_output oz inbuf 0 len)
+    write (fun () -> Bytesrw.Bytes.Writer.write_string cw inbuf);
+    flush_out ())
   >>= fun () ->
-  compress_finish oz >>= fun () ->
-  (if deflate then Lwt.return_unit else write_trailer oz) >>= fun () ->
+  write (fun () -> Bytesrw.Bytes.Writer.write_eod cw);
   Logs.debug ~src:section (fun fmt -> fmt "Close stream");
-  (try Zlib.deflate_end zstream
-   with
-   (* ignore errors, deflate_end cleans everything anyway *)
-   | Zlib.Error _ ->
-     ());
-  Lwt.return_unit
+  flush_out ()
 
 (* We implement Content-Encoding, not Transfer-Encoding *)
 type encoding = Deflate | Gzip | Id | Star | Not_acceptable
@@ -185,9 +128,10 @@ let select_encoding accept_header =
   in
   aux accept
 
-(* deflate = true -> mode deflate
-   deflate = false -> mode gzip *)
-let stream_filter contentencoding url deflate choice res =
+(* [cfilter] is the bytesrw writer filter for the negotiated codec,
+   [contentencoding] the matching Content-Encoding token, [etag_prefix] a
+   per-codec tag prepended to the ETag so that variants stay distinct. *)
+let stream_filter cfilter contentencoding etag_prefix url choice res =
   Lwt.return
     (Ocsigen.Extensions.Ext_found
        (fun () ->
@@ -212,9 +156,7 @@ let stream_filter contentencoding url deflate choice res =
                        let name = Ocsigen_http.Header.Name.(to_string etag) in
                        match Cohttp.Header.get headers name with
                        | Some e ->
-                           Cohttp.Header.replace headers name
-                             ((if deflate then "Ddeflatemod" else "Gdeflatemod")
-                             ^ e)
+                           Cohttp.Header.replace headers name (etag_prefix ^ e)
                        | None -> headers
                      in
                      let headers =
@@ -225,7 +167,7 @@ let stream_filter contentencoding url deflate choice res =
                      Http.Response.make ~headers ~status ~version ()
                    and body =
                      Ocsigen.Response.Body.make Cohttp.Transfer.Chunked
-                       (compress_body deflate
+                       (compress_body cfilter
                           (Ocsigen.Response.Body.write
                              (Ocsigen.Response.body res)))
                    in
@@ -243,13 +185,18 @@ let filter choice_list = function
       |> Ocsigen_http.Header.Accept_encoding.parse |> select_encoding
     with
     | Deflate ->
-        stream_filter "deflate"
+        (* HTTP "deflate" is the zlib format (RFC 1950), not raw deflate. *)
+        stream_filter
+          (Bytesrw_zlib.Zlib.compress_writes ~level:!compress_level ())
+          "deflate" "Ddeflatemod"
           (Ocsigen.Request.sub_path_string ri)
-          true choice_list res
+          choice_list res
     | Gzip ->
-        stream_filter "gzip"
+        stream_filter
+          (Bytesrw_zlib.Gzip.compress_writes ~level:!compress_level ())
+          "gzip" "Gdeflatemod"
           (Ocsigen.Request.sub_path_string ri)
-          false choice_list res
+          choice_list res
     | Id | Star ->
         Lwt.return (Ocsigen.Extensions.Ext_found (fun () -> Lwt.return res))
     | Not_acceptable ->

--- a/src/extensions/deflatemod.ml
+++ b/src/extensions/deflatemod.ml
@@ -277,3 +277,19 @@ let () =
     ~init_fun:parse_global_config ()
 
 let run ~mode () _ _ _ = filter mode
+
+(* Content types compressed by default in the one-command serve mode. Covers
+   the usual text-based, highly compressible resources; binary formats (images,
+   video, archives) are already compressed and left untouched. *)
+let default_serve_mode =
+  `Only
+    [ `Type (Some "text", None)
+    ; `Type (Some "application", Some "javascript")
+    ; `Type (Some "application", Some "x-javascript")
+    ; `Type (Some "application", Some "json")
+    ; `Type (Some "application", Some "xml")
+    ; `Type (Some "application", Some "xhtml+xml")
+    ; `Type (Some "application", Some "wasm")
+    ; `Type (Some "image", Some "svg+xml") ]
+
+let () = Ocsigen.Server.register_compression (run ~mode:default_serve_mode ())

--- a/src/extensions/dune
+++ b/src/extensions/dune
@@ -20,7 +20,7 @@
  (name deflatemod)
  (public_name ocsigenserver.ext.deflatemod)
  (modules deflatemod)
- (libraries camlzip ocsigenserver))
+ (libraries bytesrw bytesrw.zlib ocsigenserver))
 
 (library
  (name extendconfiguration)

--- a/src/extensions/dune
+++ b/src/extensions/dune
@@ -20,7 +20,7 @@
  (name deflatemod)
  (public_name ocsigenserver.ext.deflatemod)
  (modules deflatemod)
- (libraries bytesrw bytesrw.zlib ocsigenserver))
+ (libraries bytesrw bytesrw.zlib bytesrw.zstd ocsigenserver))
 
 (library
  (name extendconfiguration)

--- a/src/server/Ocsigen/server.ml
+++ b/src/server/Ocsigen/server.ml
@@ -482,6 +482,11 @@ let start
 let static_server : (dir:string -> instruction) option ref = ref None
 let register_static_server f = static_server := Some f
 
+(* Likewise for the Deflatemod extension, which publishes a compression
+   instruction with safe defaults so that serve mode compresses responses. *)
+let compression : instruction option ref = ref None
+let register_compression f = compression := Some f
+
 let serve ?(port = 8080) ?(directory_listing = false) ~dir () =
   (* One-command serve mode: no configuration file and no log directory are
      required. Logs go to stderr and the command pipe is placed in a temporary
@@ -491,23 +496,33 @@ let serve ?(port = 8080) ?(directory_listing = false) ~dir () =
     (Filename.concat
        (Filename.get_temp_dir_name ())
        (Printf.sprintf "ocsigenserver-%d.cmd" (Unix.getpid ())));
-  (* Load the Staticmod extension on demand. It registers its serving function
-     through [register_static_server]. *)
-  (try
-     Ocsigen_base.Loader.loadfiles
-       (fun () -> ())
-       (fun () -> ())
-       false
-       (Ocsigen_base.Loader.findfiles "ocsigenserver.ext.staticmod")
-   with e ->
-     let msg, errno = errmsg e in
-     Messages.errlog msg; exit errno);
+  (* Load an extension on demand. On failure: exit if [required], otherwise log
+     a warning and continue. *)
+  let load_extension ?(required = true) package =
+    try
+      Ocsigen_base.Loader.loadfiles
+        (fun () -> ())
+        (fun () -> ())
+        false
+        (Ocsigen_base.Loader.findfiles package)
+    with e ->
+      let msg, errno = errmsg e in
+      if required then (Messages.errlog msg; exit errno) else Messages.warning msg
+  in
+  (* Staticmod is required; Deflatemod is best-effort. Both publish their
+     instruction through the registries above. *)
+  load_extension "ocsigenserver.ext.staticmod";
+  load_extension ~required:false "ocsigenserver.ext.deflatemod";
   match !static_server with
   | None ->
       Messages.errlog
         "The Staticmod extension did not register its serving function";
       exit 1
   | Some static ->
+      (* The compression filter must come after the file server. *)
+      let instructions =
+        static ~dir :: (match !compression with Some c -> [c] | None -> [])
+      in
       start
         ~ports:[`All, port]
-        [host ~list_directory_content:directory_listing [static ~dir]]
+        [host ~list_directory_content:directory_listing instructions]

--- a/src/server/Ocsigen/server.ml
+++ b/src/server/Ocsigen/server.ml
@@ -507,7 +507,9 @@ let serve ?(port = 8080) ?(directory_listing = false) ~dir () =
         (Ocsigen_base.Loader.findfiles package)
     with e ->
       let msg, errno = errmsg e in
-      if required then (Messages.errlog msg; exit errno) else Messages.warning msg
+      if required
+      then (Messages.errlog msg; exit errno)
+      else Messages.warning msg
   in
   (* Staticmod is required; Deflatemod is best-effort. Both publish their
      instruction through the registries above. *)

--- a/src/server/Ocsigen/server.mli
+++ b/src/server/Ocsigen/server.mli
@@ -94,6 +94,11 @@ val register_static_server : (dir:string -> instruction) -> unit
     static-file serving function, so that {!serve} can use it without a static
     dependency on the extension. *)
 
+val register_compression : instruction -> unit
+(** Called by the Deflatemod extension when it is loaded to publish a
+    compression instruction with safe defaults, so that {!serve} can compress
+    responses without a static dependency on the extension. *)
+
 val host :
    ?regexp:string
   -> ?port:int

--- a/test/extensions/deflatemod.t/run.t
+++ b/test/extensions/deflatemod.t/run.t
@@ -26,25 +26,58 @@
   ocsigen:local-file: [INFO] Testing "./doesnt_exists.html".
   application: [WARNING] Command received: shutdown
 
-First response is not compressed:
+Without Accept-Encoding the response is not compressed:
 
   $ curl_ "index.html"
   HTTP/1.1 200 OK
   content-type: text/html
   server: Ocsigen
   content-length: 12
-  
+
   Hello world
 
-Second response is compressed:
+gzip:
 
-  $ curl_ "index.html" --compressed
+  $ curl_ "index.html" -H "Accept-Encoding: gzip" --compressed
   HTTP/1.1 200 OK
   content-type: text/html
   content-encoding: gzip
   server: Ocsigen
   transfer-encoding: chunked
-  
+
+  Hello world
+
+deflate (zlib format):
+
+  $ curl_ "index.html" -H "Accept-Encoding: deflate" --compressed
+  HTTP/1.1 200 OK
+  content-type: text/html
+  content-encoding: deflate
+  server: Ocsigen
+  transfer-encoding: chunked
+
+  Hello world
+
+zstd:
+
+  $ curl_ "index.html" -H "Accept-Encoding: zstd" --compressed
+  HTTP/1.1 200 OK
+  content-type: text/html
+  content-encoding: zstd
+  server: Ocsigen
+  transfer-encoding: chunked
+
+  Hello world
+
+When several codecs are offered, zstd is preferred:
+
+  $ curl_ "index.html" -H "Accept-Encoding: gzip, zstd" --compressed
+  HTTP/1.1 200 OK
+  content-type: text/html
+  content-encoding: zstd
+  server: Ocsigen
+  transfer-encoding: chunked
+
   Hello world
 
 Querying a directory or a non-existing file should give "Not found" without

--- a/test/serve.t/run.t
+++ b/test/serve.t/run.t
@@ -23,6 +23,14 @@ unreproducible "date" header is filtered out.
 
   <html>hello</html> (no-eol)
 
+Compression is on by default in serve mode: a client that accepts an encoding
+gets a compressed response.
+
+  $ curl -s -i --user-agent "" -H "Accept-Encoding: gzip" --compressed \
+  >   http://127.0.0.1:8061/index.html | grep -iE "^(HTTP|content-encoding)"
+  HTTP/1.1 200 OK
+  content-encoding: gzip
+
 A missing file gives a 404.
 
   $ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8061/nope.html


### PR DESCRIPTION
## Summary

Improves Ocsigen Server's content compression, in the spirit of the recent
quick-wins bringing it closer to mainstream static servers (Caddy, nginx).

- **zstd** content-encoding (RFC 8878) is now negotiated alongside gzip and
  deflate, preferred at equal qvalue.
- The Deflatemod backend is **switched from camlzip to `bytesrw`** (a single,
  modern, composable writer-filter abstraction for gzip/deflate/zstd). This
  removes ~90 lines of hand-written gzip framing (header, CRC32, trailer) and
  drops the camlzip dependency (it was used nowhere else).
- **Compression is enabled by default in the one-command serve mode**
  (`ocsigenserver ./public`), via a small registry mirroring the static-server
  one, so it matches `caddy file-server`.

Brotli is intentionally **not** included: there is currently no maintained
OCaml 5 binding to libbrotli (the `brotli` opam package requires `ocaml < 4.10`).
Left as a follow-up.

## Notes

- HTTP `deflate` maps to the zlib format (`Bytesrw_zlib.Zlib`), matching the
  previous camlzip behaviour (it emitted a zlib header), not raw deflate.
- New dependencies: `bytesrw`, `conf-zlib`, `conf-zstd` (system depexts:
  `libzstd-dev`, `zlib1g-dev`).

## Tests

- `deflatemod.t`: per-codec Content-Encoding (gzip, deflate, zstd) and the zstd
  preference.
- `serve.t`: serve mode compresses by default.
- `dune build @check` and `@doc` are green.