### PR TITLE
ci(doc): cache the opam switch to skip recompiling the dependency tree

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,7 +36,26 @@ jobs:
         with:
           ocaml-compiler: "5.4.0"
 
+      # The bottleneck of this job (~4.5 min) is compiling the dependency tree
+      # plus wodoc and odoc from source; setup-ocaml only caches the base switch
+      # (the compiler), so they recompiled on every push. Cache the whole _opam
+      # switch keyed on the *.opam files (the dep set) and wodoc's HEAD commit; on
+      # a cache hit the install is skipped entirely and only ocsigenserver itself
+      # is (re)built by `dune build @doc` in the next step. The key changes — and
+      # the deps/wodoc rebuild once — only when an *.opam file or wodoc move.
+      - name: Resolve wodoc HEAD commit
+        id: wodoc
+        run: echo "sha=$(git ls-remote https://github.com/ocsigen/wodoc.git HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the opam switch (deps + wodoc)
+        id: switch-cache
+        uses: actions/cache@v4
+        with:
+          path: _opam
+          key: opam-switch-${{ runner.os }}-ocaml5.4.0-${{ hashFiles('*.opam') }}-wodoc-${{ steps.wodoc.outputs.sha }}
+
       - name: Install dependencies
+        if: steps.switch-cache.outputs.cache-hit != 'true'
         run: |
           opam install . --deps-only --with-doc   # odoc is a with-doc dep
           opam pin add -n wodoc https://github.com/ocsigen/wodoc.git


### PR DESCRIPTION
## Problem

The `Documentation` workflow takes ~5 min per push, of which **~4.5 min is `Install dependencies`** — recompiling the dependency tree plus wodoc and odoc from source every time. `setup-ocaml@v3` only caches the base switch (the compiler).

| Step | Duration |
|---|---|
| Set up OCaml | ~20 s |
| **Install dependencies** | **4 min 23 s** |
| Build documentation (dev) | ~2 s |

## Fix

Cache the whole `_opam` switch with `actions/cache`, keyed on the `*.opam` files (the dependency set) and wodoc's resolved HEAD commit. On a cache hit the install step is skipped; ocsigenserver itself is still rebuilt from the checkout by `dune build @doc` in the next step, so the docs stay current. The cache rebuilds once when an `*.opam` file or wodoc's HEAD move.

This mirrors the pilot on ocsigen.github.io (4 min → ~1 min). First run on this branch is a cache miss (populates the cache); the speed-up shows on the next run.

> Doc-CI pilot for the API-project pattern. Once confirmed it rolls out to toolkit, start, tyxml, i18n, ocsipersist, lwt, reactiveData (eliom too, once its unrelated wasm_of_ocaml build breakage is fixed).